### PR TITLE
레퍼런스 라이브러리 카테고리 필터 버튼 JavaScript 구문 오류 수정

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -29845,7 +29845,7 @@ function renderReferenceLibrary() {
           </div>
           <div style="display: flex; gap: 8px; flex-wrap: wrap;" id="ref-category-filters">
             <button onclick="setRefCategoryFilter('all')" class="ref-cat-btn active" data-cat="all" style="padding: 8px 16px; border: none; border-radius: 20px; cursor: pointer; font-size: 13px; font-weight: 600; background: #0064FF; color: white;">전체</button>
-            ${REFERENCE_CATEGORIES.map(c => '<button onclick="setRefCategoryFilter(\\''+c.id+'\\')\" class="ref-cat-btn" data-cat="'+c.id+'" style="padding: 8px 16px; border: none; border-radius: 20px; cursor: pointer; font-size: 13px; font-weight: 500; background: '+c.bg+'; color: '+c.color+';">'+c.label+'</button>').join('')}
+            ${REFERENCE_CATEGORIES.map(c => '<button onclick="setRefCategoryFilter(&#39;'+c.id+'&#39;)" class="ref-cat-btn" data-cat="'+c.id+'" style="padding: 8px 16px; border: none; border-radius: 20px; cursor: pointer; font-size: 13px; font-weight: 500; background: '+c.bg+'; color: '+c.color+';">'+c.label+'</button>').join('')}
           </div>
         </div>
       </div>


### PR DESCRIPTION
- setRefCategoryFilter 함수 호출 시 잘못된 이스케이프 문자(\\') 수정
- HTML 엔티티(&#39;)를 사용하여 onclick 핸들러의 따옴표 문제 해결
- 이 오류로 인해 전체 메뉴가 클릭되지 않는 문제 해결