### PR TITLE
카페24 주문 전체 삭제 시 연동 정산도 함께 삭제 옵션 추가

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -24366,25 +24366,49 @@ async function deleteCafe24Order(docId) {
 async function deleteAllCafe24Orders() {
   // 🔒 권한 체크
   if (!canEdit()) { showNoPermission(); return; }
-  
+
   const orders = state.cafe24Orders || [];
   if (orders.length === 0) {
     showToast('삭제할 주문이 없습니다.');
     return;
   }
-  
-  if (!confirm(`⚠️ 전체 ${orders.length}건의 주문을 삭제하시겠습니까?\n\n이 작업은 되돌릴 수 없습니다.`)) return;
-  if (!confirm(`정말로 삭제하시겠습니까?`)) return;
-  
+
+  // 카페24 자동 생성 정산 데이터 확인
+  const cafe24SellerSettlements = (state.sellerSettlements || []).filter(s => s.createdBy === 'auto_cafe24_mapping');
+  const cafe24SupplierSettlements = (state.supplierSettlements || []).filter(s => s.createdBy === 'auto_cafe24_mapping');
+  const settlementCount = cafe24SellerSettlements.length + cafe24SupplierSettlements.length;
+
+  const deleteSettlements = settlementCount > 0 && confirm(
+    `📊 카페24 자동 생성 정산 ${settlementCount}건이 있습니다.\n\n` +
+    `[확인] 주문 + 정산 모두 삭제\n` +
+    `[취소] 주문만 삭제 (정산은 유지)`
+  );
+
+  if (!confirm(`⚠️ 전체 ${orders.length}건의 주문을 삭제하시겠습니까?${deleteSettlements ? `\n+ 정산 ${settlementCount}건도 함께 삭제됩니다.` : ''}\n\n이 작업은 되돌릴 수 없습니다.`)) return;
+
   try {
     showToast('🗑️ 삭제 중...');
-    
+
+    // 1. 카페24 주문 삭제
     for (const order of orders) {
       const docId = order.id;
       await db.collection('cafe24_orders').doc(docId).delete();
     }
-    
-    showToast(`✅ ${orders.length}건 전체 삭제 완료`);
+
+    // 2. 카페24 자동 생성 정산도 삭제 (사용자가 선택한 경우)
+    let deletedSettlements = 0;
+    if (deleteSettlements) {
+      for (const s of cafe24SellerSettlements) {
+        await db.collection('sellerSettlements').doc(s.id).delete();
+        deletedSettlements++;
+      }
+      for (const s of cafe24SupplierSettlements) {
+        await db.collection('supplierSettlements').doc(s.id).delete();
+        deletedSettlements++;
+      }
+    }
+
+    showToast(`✅ 주문 ${orders.length}건 삭제 완료${deletedSettlements > 0 ? ` + 정산 ${deletedSettlements}건` : ''}`);
     renderCafe24Orders();
   } catch (err) {
     console.error('전체 삭제 실패:', err);


### PR DESCRIPTION
- 전체 삭제 시 카페24 자동 생성 정산(createdBy: auto_cafe24_mapping) 확인
- 사용자 선택에 따라 주문만 삭제 또는 주문+정산 모두 삭제
- 정산관리, 셀러DB의 판매액도 함께 정리됨