### PR TITLE
카페24 엑셀 컬럼명 수정: 총 주문금액(KRW) 지원

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -7377,8 +7377,9 @@ async function parseCafe24Excel(input) {
       const productOption = (row['주문상품명(옵션포함)'] || row['상품명(옵션포함)'] || row['옵션정보'] || '').trim();
       const quantity = parseInt(row['수량'] || row['주문수량'] || row['상품수량']) || 1;
       const unitPrice = parseCafe24Amount(row['판매가'] || row['상품가격'] || row['상품금액'] || 0);
-      // 총주문금액: 여러 가능한 컬럼명 지원
+      // 총주문금액: 카페24 실제 컬럼명 포함 (KRW 표기 등)
       const totalAmount = parseCafe24Amount(
+        row['총 주문금액(KRW)'] || row['총 결제금액(KRW)'] ||  // 카페24 실제 컬럼명
         row['총주문금액'] || row['총 결제금액'] || row['결제금액'] ||
         row['상품합계'] || row['상품별 주문금액'] || row['주문금액'] ||
         row['실결제금액'] || row['총금액'] || 0


### PR DESCRIPTION
- 실제 카페24 엑셀 컬럼명: '총 주문금액(KRW)', '총 결제금액(KRW)'
- 기존 코드가 찾던 컬럼명: '총주문금액' (공백 없음, KRW 없음)
- 금액이 0원으로 나오던 버그 수정