### PR TITLE
정산서 생성 후 매출관리 대신 정산관리 페이지 유지

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -7901,8 +7901,8 @@ async function applyCafe24Mapping() {
     cafe24UploadedData = [];
     cafe24GroupedData = {};
 
-    // 매출관리 내역서로 이동
-    switchTab('salesReport');
+    // 정산관리 페이지 새로고침
+    renderSettlement();
 
   } catch (e) {
     console.error('Mapping error:', e);


### PR DESCRIPTION
- 카페24 매핑 후 switchTab('salesReport') 제거
- 대신 renderSettlement()로 현재 페이지 새로고침
- 매출관리 메뉴 제거에 따른 연동 수정