### PR TITLE
사이드바 목표달성률을 영업현황에서 직접 업데이트

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -21172,8 +21172,14 @@ function renderSalesDashboardContent(salesKRs, quarterKey) {
           }
         }
         
-        // 목표 달성률 계산 (소수 3째자리)
-        const myGoalRate = mGoal.salesAmount && mGoal.salesAmount > 0 ? (m.totalSales / mGoal.salesAmount * 100).toFixed(3) : '0.000';
+        // 목표 달성률 계산 (소수 2째자리)
+        const myGoalRate = mGoal.salesAmount && mGoal.salesAmount > 0 ? (m.totalSales / mGoal.salesAmount * 100).toFixed(2) : '0.00';
+
+        // 본인일 경우 사이드바에도 동일한 값 표시
+        if (isMe) {
+          const rateEl = document.getElementById('userGoalRate');
+          if (rateEl) rateEl.textContent = myGoalRate + '%';
+        }
         
         return `
         <div style="padding: 24px; background: ${tossColors.white}; border-radius: 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.04); ${isMe ? `border: 2px solid ${tossColors.blue};` : ''}">


### PR DESCRIPTION
- 영업현황 렌더링 시 본인 카드의 목표달성률을 사이드바에 동기화
- 소수점 2자리로 통일 (예: 0.32%)
- 영업현황과 사이드바가 항상 동일한 값 표시