### PR TITLE
어드민 로그인 후 첫 페이지를 영업현황으로 설정

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -2519,6 +2519,13 @@ function showApp() {
 
   // 사이드바 사용자 프로필 업데이트
   updateSidebarUserProfile();
+
+  // 🎯 첫 페이지를 영업현황으로 설정 (넷폼 계정 제외)
+  if (!isNetformAccount()) {
+    switchTab('salesDashboard');
+  } else {
+    switchTab('calendar');
+  }
 }
 
 // 🎯 게스트 배너 표시


### PR DESCRIPTION
- showApp() 함수에서 로그인 후 자동으로 영업현황 탭으로 이동
- 넷폼 계정은 기존처럼 캘린더가 첫 페이지