### PR TITLE
정산관리 UI 대폭 개선 (사진처럼 변경)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -13620,38 +13620,22 @@ function renderSalesReport() {
   // 정산대기 건수 (supplierPending은 sellerExternalPending과 중복되므로 제외)
   const pendingCount = sellerInhousePending.length + sellerExternalPending.length;
   const completedCount = sellerInhouseCompleted.length + sellerExternalCompleted.length;
-  
+
+  // 현재 날짜
+  const today = new Date();
+  const todayStr = `${today.getFullYear()}년 ${today.getMonth() + 1}월 ${today.getDate()}일`;
+
   app.innerHTML = `
-    <div class="page-header">
-      <h1 class="page-title">📊 매출관리 내역서</h1>
-      <p class="page-desc">내부 경영부 제출용 | 셀러/공급사 정산 기반 매출 관리</p>
-      <div class="header-actions">
+    <div style="text-align: center; padding: 40px 20px 24px; background: var(--white); border-bottom: 1px solid var(--gray-200); margin: -24px -24px 24px;">
+      <h1 style="font-size: 28px; font-weight: 700; color: var(--gray-900); margin: 0 0 8px; display: flex; align-items: center; justify-content: center; gap: 12px;">
+        <span style="font-size: 32px;">📊</span> 정산 내역서
+      </h1>
+      <p style="color: var(--gray-500); font-size: 14px; margin: 0 0 20px;">모여라딜 | ${todayStr}</p>
+      <div style="display: flex; justify-content: center; gap: 12px; flex-wrap: wrap;">
+        <button class="btn" style="background: #fef3c7; color: #92400e; border: 2px solid #f59e0b; font-weight: 700; padding: 10px 24px;" onclick="scrollToSection('pending-section')">
+          ⏳ 정산대기 ${pendingCount}건
+        </button>
         <button class="btn btn-primary" onclick="openUnifiedSettlementModal()">➕ 정산 추가</button>
-        <button class="btn btn-secondary" onclick="generateManagementReport()">📋 경영팀 정산서</button>
-        <div class="help-tooltip-wrapper" style="position: relative; display: inline-block; margin-left: 8px;">
-          <button type="button" class="help-tooltip-btn" style="width: 28px; height: 28px; border-radius: 50%; border: 1px solid var(--gray-300); background: var(--white); color: var(--gray-500); font-size: 14px; font-weight: 600; cursor: help; display: flex; align-items: center; justify-content: center;">?</button>
-          <div class="help-tooltip-content" style="display: none; position: absolute; top: 100%; right: 0; margin-top: 8px; width: 420px; background: var(--white); border-radius: 12px; box-shadow: 0 4px 20px rgba(0,0,0,0.15); padding: 16px; z-index: 100; border: 1px solid var(--gray-200);">
-            <div style="font-weight: 700; color: var(--gray-900); margin-bottom: 12px; font-size: 14px;">💡 매출 및 비용 구조</div>
-            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 12px;">
-              <div style="background: var(--info-light); border-radius: 8px; padding: 12px;">
-                <div style="font-weight: 600; color: var(--info); margin-bottom: 6px; font-size: 13px;">1. 자사 상품</div>
-                <div style="font-size: 12px; color: var(--gray-700); line-height: 1.6;">
-                  • 매출금액 = 판매금액<br>
-                  • 비용 = 셀러 수수료<br>
-                  <span style="color: var(--info); font-weight: 500;">👤 셀러 정산만 진행</span>
-                </div>
-              </div>
-              <div style="background: var(--success-light); border-radius: 8px; padding: 12px;">
-                <div style="font-weight: 600; color: var(--success); margin-bottom: 6px; font-size: 13px;">2. 타사 상품</div>
-                <div style="font-size: 12px; color: var(--gray-700); line-height: 1.6;">
-                  • 매출금액 = 판매금액 - 공급가액<br>
-                  • 비용 = 공급가액 + 셀러 수수료<br>
-                  <span style="color: var(--success); font-weight: 500;">👤 셀러 + 🏭 공급사 정산</span>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
       </div>
     </div>
     
@@ -13735,31 +13719,99 @@ function renderSalesReport() {
     </div>
     
     <!-- ========== 정산대기 섹션 ========== -->
-    <div style="background: var(--white); border: 1px solid var(--gray-200); border-radius: 12px; padding: 16px 20px; margin-bottom: 24px; display: flex; align-items: center; gap: 12px;">
-      <span style="font-size: 24px;">⏳</span>
-      <div>
-        <h2 style="margin: 0; font-size: 18px; font-weight: 700; color: var(--gray-600);">정산대기</h2>
-        <p style="margin: 4px 0 0; font-size: 13px; color: #b45309;">아래 항목들은 경영팀 정산서에 포함됩니다</p>
+    <div id="pending-section" style="background: var(--white); border: 1px solid var(--gray-200); border-radius: 12px; padding: 16px 20px; margin-bottom: 24px;">
+      <div style="display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap; gap: 12px;">
+        <div style="display: flex; align-items: center; gap: 12px;">
+          <span style="font-size: 24px;">⏳</span>
+          <div>
+            <h2 style="margin: 0; font-size: 18px; font-weight: 700; color: var(--gray-600);">정산대기</h2>
+            <p style="margin: 4px 0 0; font-size: 13px; color: #b45309;">선택한 항목을 정산서 보기 또는 삭제할 수 있습니다</p>
+          </div>
+          <span style="background: #dc2626; color: white; padding: 6px 14px; border-radius: 20px; font-weight: 700; font-size: 14px;">${pendingCount}건</span>
+        </div>
+        <div style="display: flex; gap: 8px; flex-wrap: wrap;">
+          <button class="btn btn-secondary btn-sm" onclick="viewSelectedSellerStatements()">👤 셀러 정산서</button>
+          <button class="btn btn-secondary btn-sm" onclick="viewSelectedSupplierStatements()">🏭 공급사 정산서</button>
+          <button class="btn btn-sm" style="background: #dc2626; color: white;" onclick="deleteSelectedSettlements()">🗑️ 선택 삭제</button>
+        </div>
       </div>
-      <span style="margin-left: auto; background: #dc2626; color: white; padding: 6px 14px; border-radius: 20px; font-weight: 700; font-size: 14px;">${pendingCount}건</span>
     </div>
-    
+
     <!-- 1 자사 상품 셀러 정산 (대기) -->
     <div class="card">
-      <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
+      <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; flex-wrap: wrap; gap: 12px;">
         <h2 class="card-title" style="color: var(--info); margin: 0; display: flex; align-items: center; gap: 8px;">
           <span style="background: var(--info); color: #fff; width: 28px; height: 28px; border-radius: 8px; display: flex; align-items: center; justify-content: center; font-size: 14px;">1</span>
           자사 상품 - 셀러 정산
+          <span style="background: var(--gray-100); color: var(--gray-600); padding: 4px 10px; border-radius: 12px; font-size: 12px; font-weight: 500;">${sellerInhousePending.length}건</span>
         </h2>
-        <span class="status-badge" style="background: var(--gray-100); color: var(--gray-600);">${sellerInhousePending.length}건 대기</span>
       </div>
       ${sellerInhousePending.length === 0 ? '<div style="text-align: center; padding: 20px; color: var(--gray-500);">✅ 정산대기 항목이 없습니다</div>' : `
         <div style="overflow-x: auto;">
           <table class="data-table">
-            <thead><tr><th>셀러명</th><th>브랜드</th><th>공구기간</th><th style="text-align:center;">수량</th><th style="text-align:right;">판매금액</th><th style="text-align:right;color:var(--danger);">마진금액</th><th style="text-align:right;">원천세</th><th style="text-align:right;color:var(--success);">실지급액</th><th>정산일</th><th style="text-align:center;">관리</th></tr></thead>
+            <thead>
+              <tr>
+                <th style="width:40px;"><input type="checkbox" onchange="toggleAllInhouseCheck(this.checked)" style="width:18px;height:18px;cursor:pointer;"></th>
+                <th>셀러명</th>
+                <th>브랜드</th>
+                <th>공구기간</th>
+                <th>판매상품</th>
+                <th style="text-align:right;">단가</th>
+                <th style="text-align:center;">수량</th>
+                <th style="text-align:right;">판매금액</th>
+                <th style="text-align:right;">마진금액</th>
+                <th style="text-align:right;">원천세</th>
+                <th style="text-align:right;">소계</th>
+                <th style="text-align:right;background:#dcfce7;color:#166534;">총실지급액</th>
+                <th>정산일</th>
+                <th style="text-align:center;">관리</th>
+              </tr>
+            </thead>
             <tbody>
-              ${sellerInhousePending.map(s => `<tr><td><strong>${s.sellerName||'-'}</strong></td><td><span class="status-badge status-confirmed">${s.brandName||'-'}</span></td><td style="font-size:13px;">${s.dealPeriod||'-'}</td><td style="text-align:center;font-weight:600;">${s.totalQuantity||'-'}</td><td style="text-align:right;font-weight:600;">${Number(s.salesAmount||0).toLocaleString()}원</td><td style="text-align:right;color:var(--danger);">${Number(s.marginAmount||0).toLocaleString()}원</td><td style="text-align:right;font-size:12px;">${Number(s.withholdingTax||0).toLocaleString()}원</td><td style="text-align:right;color:var(--success);font-weight:600;">${Number(s.actualPayment||0).toLocaleString()}원</td><td>${s.settlementDate||'-'}</td><td class="actions" style="white-space:nowrap;"><div style="display:flex;flex-direction:column;gap:6px;align-items:center;"><div style="display:flex;gap:4px;"><button class="btn btn-secondary btn-sm" onclick="openUnifiedSettlementModal(state.sellerSettlements.find(x=>x.id==='${s.id}'))">수정</button><button class="btn btn-secondary btn-sm" onclick="generateSellerStatement('${s.id}')">📄</button></div><label style="display:flex;align-items:center;gap:4px;font-size:11px;color:var(--gray-600);cursor:pointer;"><input type="checkbox" onchange="toggleSettlementComplete('seller','${s.id}',true)" style="width:16px;height:16px;cursor:pointer;"><span>완료</span></label></div></td></tr>`).join('')}
+              ${sellerInhousePending.map(s => {
+                const items = s.salesItems || [{productName: s.productName || '-', quantity: s.totalQuantity || 1, unitPrice: s.salePrice || 0, amount: s.salesAmount || 0}];
+                const rowspan = items.length;
+                return items.map((item, idx) => `<tr>
+                  ${idx === 0 ? `<td rowspan="${rowspan}" style="text-align:center;"><input type="checkbox" class="inhouse-check" data-id="${s.id}" style="width:18px;height:18px;cursor:pointer;"></td>` : ''}
+                  ${idx === 0 ? `<td rowspan="${rowspan}"><strong>${s.sellerName||'-'}</strong></td>` : ''}
+                  ${idx === 0 ? `<td rowspan="${rowspan}"><span class="status-badge status-confirmed">${s.brandName||'-'}</span></td>` : ''}
+                  ${idx === 0 ? `<td rowspan="${rowspan}" style="font-size:12px;">${s.dealPeriod||'-'}</td>` : ''}
+                  <td style="font-size:12px;max-width:150px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="${item.productName||'-'}">${item.productName||'-'}</td>
+                  <td style="text-align:right;font-size:12px;">${Number(item.unitPrice||0).toLocaleString()}원</td>
+                  <td style="text-align:center;">${item.quantity||1}</td>
+                  <td style="text-align:right;">${Number(item.amount||0).toLocaleString()}원</td>
+                  ${idx === 0 ? `<td rowspan="${rowspan}" style="text-align:right;">${Number(s.marginAmount||0).toLocaleString()}원</td>` : ''}
+                  ${idx === 0 ? `<td rowspan="${rowspan}" style="text-align:right;font-size:12px;">${Number(s.withholdingTax||0).toLocaleString()}원</td>` : ''}
+                  ${idx === 0 ? `<td rowspan="${rowspan}" style="text-align:right;">${Number((s.marginAmount||0)-(s.withholdingTax||0)).toLocaleString()}원</td>` : ''}
+                  ${idx === 0 ? `<td rowspan="${rowspan}" style="text-align:right;background:#dcfce7;font-weight:700;color:#166534;">${Number(s.actualPayment||0).toLocaleString()}원</td>` : ''}
+                  ${idx === 0 ? `<td rowspan="${rowspan}">${s.settlementDate||'-'}</td>` : ''}
+                  ${idx === 0 ? `<td rowspan="${rowspan}" class="actions" style="white-space:nowrap;">
+                    <div style="display:flex;flex-direction:column;gap:4px;align-items:center;">
+                      <div style="display:flex;gap:4px;">
+                        <button class="btn btn-secondary btn-sm" onclick="openUnifiedSettlementModal(state.sellerSettlements.find(x=>x.id==='${s.id}'))" title="수정">✏️</button>
+                        <button class="btn btn-secondary btn-sm" onclick="generateSellerStatement('${s.id}')" title="셀러 정산서">📄</button>
+                        <button class="btn btn-sm" style="background:#fee2e2;color:#dc2626;" onclick="confirmDeleteSettlement('seller','${s.id}')" title="삭제">🗑️</button>
+                      </div>
+                      <label style="display:flex;align-items:center;gap:4px;font-size:10px;color:var(--gray-600);cursor:pointer;">
+                        <input type="checkbox" onchange="toggleSettlementComplete('seller','${s.id}',true)" style="width:14px;height:14px;cursor:pointer;">
+                        <span>완료처리</span>
+                      </label>
+                    </div>
+                  </td>` : ''}
+                </tr>`).join('');
+              }).join('')}
             </tbody>
+            <tfoot>
+              <tr style="background:#f3f4f6;font-weight:600;">
+                <td colspan="7" style="text-align:center;">합계</td>
+                <td style="text-align:right;">${sellerInhousePending.reduce((sum,s) => sum + Number(s.salesAmount||0), 0).toLocaleString()}원</td>
+                <td style="text-align:right;">${sellerInhousePending.reduce((sum,s) => sum + Number(s.marginAmount||0), 0).toLocaleString()}원</td>
+                <td style="text-align:right;">${sellerInhousePending.reduce((sum,s) => sum + Number(s.withholdingTax||0), 0).toLocaleString()}원</td>
+                <td></td>
+                <td style="text-align:right;background:#dcfce7;font-weight:700;color:#166534;">${sellerInhousePending.reduce((sum,s) => sum + Number(s.actualPayment||0), 0).toLocaleString()}원</td>
+                <td colspan="2"></td>
+              </tr>
+            </tfoot>
           </table>
         </div>
       `}
@@ -13767,84 +13819,123 @@ function renderSalesReport() {
     
     <!-- 2 타사 상품 - 셀러/공급사 정산 (대기) - 통합 -->
     <div class="card">
-      <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
+      <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; flex-wrap: wrap; gap: 12px;">
         <h2 class="card-title" style="color: var(--success); margin: 0; display: flex; align-items: center; gap: 8px;">
           <span style="background: var(--success); color: #fff; width: 28px; height: 28px; border-radius: 8px; display: flex; align-items: center; justify-content: center; font-size: 14px;">2</span>
           타사 상품 - 셀러/공급사 정산
+          <span style="background: var(--gray-100); color: var(--gray-600); padding: 4px 10px; border-radius: 12px; font-size: 12px; font-weight: 500;">${sellerExternalPending.length}건</span>
         </h2>
-        <div style="display: flex; gap: 8px; align-items: center;">
-          <button class="btn btn-secondary btn-sm" onclick="openSupplierProductModal()">📦 상품관리</button>
-          <span class="status-badge" style="background: var(--gray-100); color: var(--gray-600);">${sellerExternalPending.length}건 대기</span>
-        </div>
+        <button class="btn btn-secondary btn-sm" onclick="openSupplierProductModal()">📦 상품관리</button>
       </div>
       ${sellerExternalPending.length === 0 ? '<div style="text-align: center; padding: 20px; color: var(--gray-500);">✅ 정산대기 항목이 없습니다</div>' : `
         <div style="overflow-x: auto;">
           <table class="data-table">
             <thead>
               <tr>
+                <th rowspan="2" style="width:40px;vertical-align:middle;"><input type="checkbox" onchange="toggleAllExternalCheck(this.checked)" style="width:18px;height:18px;cursor:pointer;"></th>
                 <th rowspan="2" style="vertical-align:middle;">셀러명</th>
                 <th rowspan="2" style="vertical-align:middle;">브랜드(공급사)</th>
                 <th rowspan="2" style="vertical-align:middle;">공구기간</th>
+                <th rowspan="2" style="vertical-align:middle;">판매상품</th>
+                <th rowspan="2" style="text-align:right;vertical-align:middle;">단가</th>
                 <th rowspan="2" style="text-align:center;vertical-align:middle;">수량</th>
                 <th rowspan="2" style="text-align:right;vertical-align:middle;">판매금액</th>
-                <th colspan="3" style="text-align:center;background:#dcfce7;border-bottom:1px solid var(--gray-300);">셀러 정산</th>
-                <th colspan="3" style="text-align:center;background:#fef9c3;border-bottom:1px solid var(--gray-300);">공급사 정산</th>
+                <th colspan="4" style="text-align:center;background:#dcfce7;border-bottom:1px solid var(--gray-300);">- 셀러 정산 -</th>
+                <th colspan="4" style="text-align:center;background:#fef9c3;border-bottom:1px solid var(--gray-300);">- 공급사 정산 -</th>
                 <th rowspan="2" style="vertical-align:middle;">정산일</th>
                 <th rowspan="2" style="text-align:center;vertical-align:middle;">관리</th>
               </tr>
               <tr>
                 <th style="text-align:right;background:#dcfce7;font-size:11px;">마진금액</th>
                 <th style="text-align:right;background:#dcfce7;font-size:11px;">원천세</th>
-                <th style="text-align:right;background:#dcfce7;font-size:11px;">실지급액</th>
+                <th style="text-align:right;background:#dcfce7;font-size:11px;">소계</th>
+                <th style="text-align:right;background:#dcfce7;font-size:11px;">총실지급액</th>
                 <th style="text-align:right;background:#fef9c3;font-size:11px;">공급가액</th>
-                <th style="text-align:right;background:#fef9c3;font-size:11px;">부가세</th>
+                <th style="text-align:right;background:#fef9c3;font-size:11px;">부가세(10%)</th>
+                <th style="text-align:right;background:#fef9c3;font-size:11px;">총합계</th>
                 <th style="text-align:right;background:#fef9c3;font-size:11px;">정산금액(V+)</th>
               </tr>
             </thead>
             <tbody>
               ${sellerExternalPending.map(s => {
                 // 연결된 공급사 정산 찾기
-                const supplierData = state.supplierSettlements.find(sup => 
-                  sup.sellerName === s.sellerName && 
-                  sup.brandName === s.brandName && 
+                const supplierData = state.supplierSettlements.find(sup =>
+                  sup.sellerName === s.sellerName &&
+                  sup.brandName === s.brandName &&
                   sup.dealPeriod === s.dealPeriod
                 ) || {};
                 const supplierId = supplierData.id || '';
-                return `<tr>
-                  <td><strong>${s.sellerName||'-'}</strong></td>
-                  <td><span class="status-badge status-negotiating">${s.brandName||'-'}</span></td>
-                  <td style="font-size:13px;">${s.dealPeriod||'-'}</td>
-                  <td style="text-align:center;font-weight:600;">${s.totalQuantity||'-'}</td>
-                  <td style="text-align:right;font-weight:600;">${Number(s.salesAmount||0).toLocaleString()}원</td>
-                  <td style="text-align:right;background:#f0fdf4;">${Number(s.marginAmount||0).toLocaleString()}원</td>
-                  <td style="text-align:right;background:#f0fdf4;font-size:12px;">${Number(s.withholdingTax||0).toLocaleString()}원</td>
-                  <td style="text-align:right;background:#f0fdf4;font-weight:600;">${Number(s.actualPayment||0).toLocaleString()}원</td>
-                  <td style="text-align:right;background:#fefce8;">${Number(supplierData.totalSupplyAmount||s.supplyAmount||0).toLocaleString()}원</td>
-                  <td style="text-align:right;background:#fefce8;font-size:12px;">${Number(supplierData.totalVatAmount||s.vatAmount||0).toLocaleString()}원</td>
-                  <td style="text-align:right;background:#fefce8;font-weight:600;">${Number(supplierData.totalAmount||s.supplierTotalAmount||0).toLocaleString()}원</td>
-                  <td>${s.settlementDate||'-'}</td>
-                  <td class="actions" style="white-space:nowrap;">
-                    <div style="display:flex;flex-direction:column;gap:6px;align-items:center;">
-                      <div style="display:flex;gap:4px;">
-                        <button class="btn btn-secondary btn-sm" onclick="openUnifiedSettlementModal(state.sellerSettlements.find(x=>x.id==='${s.id}'))">수정</button>
+                // 상품 정보
+                const items = s.salesItems || [{productName: s.productName || '-', quantity: s.totalQuantity || 1, unitPrice: s.salePrice || 0, amount: s.salesAmount || 0}];
+                const rowspan = items.length;
+                // 소계 계산
+                const sellerSubtotal = Number(s.marginAmount||0) - Number(s.withholdingTax||0);
+                const supplierSubtotal = Number(supplierData.totalSupplyAmount||s.supplyAmount||0) + Number(supplierData.totalVatAmount||s.vatAmount||0);
+                return items.map((item, idx) => `<tr>
+                  ${idx === 0 ? `<td rowspan="${rowspan}" style="text-align:center;"><input type="checkbox" class="external-check" data-id="${s.id}" data-supplier-id="${supplierId}" style="width:18px;height:18px;cursor:pointer;"></td>` : ''}
+                  ${idx === 0 ? `<td rowspan="${rowspan}"><strong>${s.sellerName||'-'}</strong></td>` : ''}
+                  ${idx === 0 ? `<td rowspan="${rowspan}"><span class="status-badge status-negotiating">${s.brandName||'-'}</span></td>` : ''}
+                  ${idx === 0 ? `<td rowspan="${rowspan}" style="font-size:12px;">${s.dealPeriod||'-'}</td>` : ''}
+                  <td style="font-size:12px;max-width:150px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="${item.productName||'-'}">${item.productName||'-'}</td>
+                  <td style="text-align:right;font-size:12px;">${Number(item.unitPrice||0).toLocaleString()}원</td>
+                  <td style="text-align:center;">${item.quantity||1}</td>
+                  <td style="text-align:right;">${Number(item.amount||0).toLocaleString()}원</td>
+                  ${idx === 0 ? `<td rowspan="${rowspan}" style="text-align:right;background:#f0fdf4;">${Number(s.marginAmount||0).toLocaleString()}원</td>` : ''}
+                  ${idx === 0 ? `<td rowspan="${rowspan}" style="text-align:right;background:#f0fdf4;font-size:12px;">${Number(s.withholdingTax||0).toLocaleString()}원</td>` : ''}
+                  ${idx === 0 ? `<td rowspan="${rowspan}" style="text-align:right;background:#f0fdf4;">${sellerSubtotal.toLocaleString()}원</td>` : ''}
+                  ${idx === 0 ? `<td rowspan="${rowspan}" style="text-align:right;background:#dcfce7;font-weight:700;color:#166534;">${Number(s.actualPayment||0).toLocaleString()}원</td>` : ''}
+                  ${idx === 0 ? `<td rowspan="${rowspan}" style="text-align:right;background:#fefce8;">${Number(supplierData.totalSupplyAmount||s.supplyAmount||0).toLocaleString()}원</td>` : ''}
+                  ${idx === 0 ? `<td rowspan="${rowspan}" style="text-align:right;background:#fefce8;font-size:12px;">${Number(supplierData.totalVatAmount||s.vatAmount||0).toLocaleString()}원</td>` : ''}
+                  ${idx === 0 ? `<td rowspan="${rowspan}" style="text-align:right;background:#fefce8;">${supplierSubtotal.toLocaleString()}원</td>` : ''}
+                  ${idx === 0 ? `<td rowspan="${rowspan}" style="text-align:right;background:#fde68a;font-weight:700;color:#92400e;">${Number(supplierData.totalAmount||s.supplierTotalAmount||0).toLocaleString()}원</td>` : ''}
+                  ${idx === 0 ? `<td rowspan="${rowspan}">${s.settlementDate||'-'}</td>` : ''}
+                  ${idx === 0 ? `<td rowspan="${rowspan}" class="actions" style="white-space:nowrap;">
+                    <div style="display:flex;flex-direction:column;gap:4px;align-items:center;">
+                      <div style="display:flex;gap:3px;">
+                        <button class="btn btn-secondary btn-sm" onclick="openUnifiedSettlementModal(state.sellerSettlements.find(x=>x.id==='${s.id}'))" title="수정">✏️</button>
                         <button class="btn btn-secondary btn-sm" onclick="generateSellerStatement('${s.id}')" title="셀러 정산서">👤</button>
                         <button class="btn btn-secondary btn-sm" onclick="generateSupplierStatement('${s.id}')" title="공급사 정산서">🏭</button>
+                        <button class="btn btn-sm" style="background:#fee2e2;color:#dc2626;" onclick="confirmDeleteSettlement('seller','${s.id}','${supplierId}')" title="삭제">🗑️</button>
                       </div>
-                      <div style="display:flex;flex-direction:column;gap:3px;font-size:10px;">
-                        <label style="display:flex;align-items:center;gap:3px;color:#16a34a;cursor:pointer;">
-                          <input type="checkbox" ${s.isSellerCompleted ? 'checked' : ''} onchange="toggleExternalSettlement('seller','${s.id}',this.checked)" style="width:14px;height:14px;cursor:pointer;accent-color:#16a34a;">
-                          <span>셀러완료</span>
+                      <div style="display:flex;gap:6px;font-size:10px;">
+                        <label style="display:flex;align-items:center;gap:2px;color:#16a34a;cursor:pointer;">
+                          <input type="checkbox" ${s.isSellerCompleted ? 'checked' : ''} onchange="toggleExternalSettlement('seller','${s.id}',this.checked)" style="width:12px;height:12px;cursor:pointer;accent-color:#16a34a;">
+                          <span>셀러</span>
                         </label>
-                        <label style="display:flex;align-items:center;gap:3px;color:#ca8a04;cursor:pointer;">
-                          <input type="checkbox" ${supplierData.isCompleted ? 'checked' : ''} onchange="toggleExternalSettlement('supplier','${supplierId}',this.checked)" style="width:14px;height:14px;cursor:pointer;accent-color:#ca8a04;" ${!supplierId ? 'disabled title="공급사 정산 데이터 없음"' : ''}>
-                          <span>공급사완료</span>
+                        <label style="display:flex;align-items:center;gap:2px;color:#ca8a04;cursor:pointer;">
+                          <input type="checkbox" ${supplierData.isCompleted ? 'checked' : ''} onchange="toggleExternalSettlement('supplier','${supplierId}',this.checked)" style="width:12px;height:12px;cursor:pointer;accent-color:#ca8a04;" ${!supplierId ? 'disabled' : ''}>
+                          <span>공급사</span>
                         </label>
                       </div>
                     </div>
-                  </td>
-                </tr>`;
+                  </td>` : ''}
+                </tr>`).join('');
               }).join('')}
             </tbody>
+            <tfoot>
+              <tr style="background:#f3f4f6;font-weight:600;">
+                <td colspan="7" style="text-align:center;">합계</td>
+                <td style="text-align:right;">${sellerExternalPending.reduce((sum,s) => sum + Number(s.salesAmount||0), 0).toLocaleString()}원</td>
+                <td style="text-align:right;background:#f0fdf4;">${sellerExternalPending.reduce((sum,s) => sum + Number(s.marginAmount||0), 0).toLocaleString()}원</td>
+                <td style="text-align:right;background:#f0fdf4;">${sellerExternalPending.reduce((sum,s) => sum + Number(s.withholdingTax||0), 0).toLocaleString()}원</td>
+                <td style="background:#f0fdf4;"></td>
+                <td style="text-align:right;background:#dcfce7;font-weight:700;color:#166534;">${sellerExternalPending.reduce((sum,s) => sum + Number(s.actualPayment||0), 0).toLocaleString()}원</td>
+                <td style="text-align:right;background:#fefce8;">${sellerExternalPending.reduce((sum,s) => {
+                  const supplierData = state.supplierSettlements.find(sup => sup.sellerName === s.sellerName && sup.brandName === s.brandName && sup.dealPeriod === s.dealPeriod) || {};
+                  return sum + Number(supplierData.totalSupplyAmount||s.supplyAmount||0);
+                }, 0).toLocaleString()}원</td>
+                <td style="text-align:right;background:#fefce8;">${sellerExternalPending.reduce((sum,s) => {
+                  const supplierData = state.supplierSettlements.find(sup => sup.sellerName === s.sellerName && sup.brandName === s.brandName && sup.dealPeriod === s.dealPeriod) || {};
+                  return sum + Number(supplierData.totalVatAmount||s.vatAmount||0);
+                }, 0).toLocaleString()}원</td>
+                <td style="background:#fefce8;"></td>
+                <td style="text-align:right;background:#fde68a;font-weight:700;color:#92400e;">${sellerExternalPending.reduce((sum,s) => {
+                  const supplierData = state.supplierSettlements.find(sup => sup.sellerName === s.sellerName && sup.brandName === s.brandName && sup.dealPeriod === s.dealPeriod) || {};
+                  return sum + Number(supplierData.totalAmount||s.supplierTotalAmount||0);
+                }, 0).toLocaleString()}원</td>
+                <td colspan="2"></td>
+              </tr>
+            </tfoot>
           </table>
         </div>
         <div style="margin-top: 12px; padding: 12px; background: var(--gray-50); border-radius: 8px; font-size: 12px; color: var(--gray-600);">
@@ -14005,6 +14096,169 @@ function renderSalesReport() {
       </div>
     </div>
   `;
+}
+
+// 섹션으로 스크롤
+function scrollToSection(sectionId) {
+  const el = document.getElementById(sectionId);
+  if (el) {
+    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+}
+
+// 자사상품 체크박스 전체 선택/해제
+function toggleAllInhouseCheck(checked) {
+  document.querySelectorAll('.inhouse-check').forEach(cb => cb.checked = checked);
+}
+
+// 타사상품 체크박스 전체 선택/해제
+function toggleAllExternalCheck(checked) {
+  document.querySelectorAll('.external-check').forEach(cb => cb.checked = checked);
+}
+
+// 선택된 셀러 정산서 보기
+function viewSelectedSellerStatements() {
+  const inhouseIds = Array.from(document.querySelectorAll('.inhouse-check:checked')).map(cb => cb.dataset.id);
+  const externalIds = Array.from(document.querySelectorAll('.external-check:checked')).map(cb => cb.dataset.id);
+  const allIds = [...inhouseIds, ...externalIds];
+
+  if (allIds.length === 0) {
+    showToast('정산서를 볼 항목을 선택해주세요', 'warning');
+    return;
+  }
+
+  // 첫 번째 선택 항목의 셀러 정산서 표시
+  generateSellerStatement(allIds[0]);
+
+  if (allIds.length > 1) {
+    showToast(`${allIds.length}건 중 첫 번째 셀러 정산서를 표시합니다. 개별적으로 확인하세요.`, 'info');
+  }
+}
+
+// 선택된 공급사 정산서 보기
+function viewSelectedSupplierStatements() {
+  const externalIds = Array.from(document.querySelectorAll('.external-check:checked')).map(cb => cb.dataset.id);
+
+  if (externalIds.length === 0) {
+    showToast('공급사 정산서를 볼 타사상품을 선택해주세요', 'warning');
+    return;
+  }
+
+  // 첫 번째 선택 항목의 공급사 정산서 표시
+  generateSupplierStatement(externalIds[0]);
+
+  if (externalIds.length > 1) {
+    showToast(`${externalIds.length}건 중 첫 번째 공급사 정산서를 표시합니다. 개별적으로 확인하세요.`, 'info');
+  }
+}
+
+// 선택된 정산 삭제
+function deleteSelectedSettlements() {
+  const inhouseChecks = Array.from(document.querySelectorAll('.inhouse-check:checked'));
+  const externalChecks = Array.from(document.querySelectorAll('.external-check:checked'));
+
+  const totalCount = inhouseChecks.length + externalChecks.length;
+
+  if (totalCount === 0) {
+    showToast('삭제할 항목을 선택해주세요', 'warning');
+    return;
+  }
+
+  showDeleteConfirmModal({
+    title: '선택 항목 삭제',
+    message: `<strong>${totalCount}건</strong>의 정산 데이터를 삭제합니다.<br><br>
+      • 자사상품: ${inhouseChecks.length}건<br>
+      • 타사상품: ${externalChecks.length}건<br><br>
+      ⚠️ 이 작업은 되돌릴 수 없습니다.`,
+    deleteType: 'bulk',
+    onConfirm: async (method) => {
+      try {
+        // 자사상품 삭제
+        for (const cb of inhouseChecks) {
+          const id = cb.dataset.id;
+          if (method === 'hard') {
+            await db.collection('sellerSettlements').doc(id).delete();
+          } else {
+            await db.collection('sellerSettlements').doc(id).update({
+              isDeleted: true,
+              deletedAt: new Date().toISOString()
+            });
+          }
+        }
+
+        // 타사상품 삭제 (셀러 + 공급사)
+        for (const cb of externalChecks) {
+          const sellerId = cb.dataset.id;
+          const supplierId = cb.dataset.supplierId;
+
+          if (method === 'hard') {
+            await db.collection('sellerSettlements').doc(sellerId).delete();
+            if (supplierId) {
+              await db.collection('supplierSettlements').doc(supplierId).delete();
+            }
+          } else {
+            await db.collection('sellerSettlements').doc(sellerId).update({
+              isDeleted: true,
+              deletedAt: new Date().toISOString()
+            });
+            if (supplierId) {
+              await db.collection('supplierSettlements').doc(supplierId).update({
+                isDeleted: true,
+                deletedAt: new Date().toISOString()
+              });
+            }
+          }
+        }
+
+        showToast(`✅ ${totalCount}건이 삭제되었습니다`);
+        renderSettlement();
+      } catch (err) {
+        console.error(err);
+        showToast('삭제 중 오류가 발생했습니다', 'error');
+      }
+    }
+  });
+}
+
+// 개별 정산 삭제 확인
+function confirmDeleteSettlement(type, sellerId, supplierId = '') {
+  const settlement = state.sellerSettlements.find(s => s.id === sellerId);
+  const name = settlement ? `${settlement.sellerName} - ${settlement.brandName}` : '정산';
+
+  showDeleteConfirmModal({
+    title: '정산 데이터 삭제',
+    message: `<strong>${name}</strong> 정산 데이터를 삭제합니다.<br><br>
+      ${supplierId ? '• 셀러 정산 + 공급사 정산이 함께 삭제됩니다<br>' : ''}
+      ⚠️ 이 작업은 되돌릴 수 없습니다.`,
+    deleteType: 'single',
+    onConfirm: async (method) => {
+      try {
+        if (method === 'hard') {
+          await db.collection('sellerSettlements').doc(sellerId).delete();
+          if (supplierId) {
+            await db.collection('supplierSettlements').doc(supplierId).delete();
+          }
+        } else {
+          await db.collection('sellerSettlements').doc(sellerId).update({
+            isDeleted: true,
+            deletedAt: new Date().toISOString()
+          });
+          if (supplierId) {
+            await db.collection('supplierSettlements').doc(supplierId).update({
+              isDeleted: true,
+              deletedAt: new Date().toISOString()
+            });
+          }
+        }
+
+        showToast('✅ 삭제되었습니다');
+        renderSettlement();
+      } catch (err) {
+        console.error(err);
+        showToast('삭제 중 오류가 발생했습니다', 'error');
+      }
+    }
+  });
 }
 
 // 정산완료 섹션 접기/펼치기


### PR DESCRIPTION
- 페이지 헤더: "정산 내역서" 스타일로 변경, 날짜 표시
- 정산대기 버튼 추가 (클릭시 해당 섹션으로 스크롤)
- 자사상품/타사상품 테이블에 판매상품, 단가 컬럼 추가
- 체크박스로 개별/전체 선택 기능 추가
- 셀러/공급사 정산서 보기 버튼 추가
- 개별 삭제 및 선택 삭제 기능 추가 (삭제 확인 모달 포함)
- 타사상품 테이블에 소계, 총합계 컬럼 추가
- 합계 행 추가
- 녹색/노란색 컬럼으로 셀러/공급사 정산 항목 구분