### PR TITLE
정산 로직 개선 및 정산서 표시 수정

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -7947,11 +7947,18 @@ function viewSettlementReport(dealId) {
     marginRate = marginRate || deal.sellerMarginRate || 10;
     supplyPrice = supplyPrice || deal.supplyPrice || 0;
 
-    const marginAmount = Math.round(group.totalAmount * marginRate / 100);
-    const supplyTotal = supplyPrice * group.quantity;
+    // 🎯 타사 상품: supplyPrice가 0이면 판매단가에서 마진율 빼서 자동 계산
+    // 공급단가 = 판매단가 * (100 - 마진율) / 100
     const unitPrice = group.orders.length > 0
       ? Math.round(group.totalAmount / group.quantity)
       : 0;
+
+    if (isExternal && supplyPrice === 0 && unitPrice > 0 && marginRate > 0) {
+      supplyPrice = Math.round(unitPrice * (100 - marginRate) / 100);
+    }
+
+    const marginAmount = Math.round(group.totalAmount * marginRate / 100);
+    const supplyTotal = supplyPrice * group.quantity;
 
     return {
       productName: group.productName,
@@ -8125,35 +8132,6 @@ function viewSettlementReport(dealId) {
             </table>
           </div>
         `}
-
-        <!-- 모여라딜 순이익 -->
-        <div style="background: white; border: 1px solid var(--gray-200); border-radius: 12px; padding: 16px; margin-bottom: 16px;">
-          <h3 style="font-size: 14px; font-weight: 600; margin-bottom: 12px; color: var(--primary);">💰 모여라딜 정산</h3>
-          <table style="width: 100%; font-size: 13px;">
-            <tr style="border-bottom: 1px solid var(--gray-100);">
-              <td style="padding: 8px 0; color: var(--gray-600);">총 판매금액</td>
-              <td style="padding: 8px 0; text-align: right; font-weight: 600;">${formatNumber(totalSales)}원</td>
-            </tr>
-            <tr style="border-bottom: 1px solid var(--gray-100);">
-              <td style="padding: 8px 0; color: #dc2626;">PG수수료 (4%)</td>
-              <td style="padding: 8px 0; text-align: right; color: #dc2626;">-${formatNumber(pgFee)}원</td>
-            </tr>
-            ${isExternal ? `
-              <tr style="border-bottom: 1px solid var(--gray-100);">
-                <td style="padding: 8px 0; color: #92400e;">공급사 지급액</td>
-                <td style="padding: 8px 0; text-align: right; color: #92400e;">-${formatNumber(supplierPayout)}원</td>
-              </tr>
-            ` : ''}
-            <tr style="border-bottom: 1px solid var(--gray-100);">
-              <td style="padding: 8px 0; color: #1d4ed8;">셀러 지급액</td>
-              <td style="padding: 8px 0; text-align: right; color: #1d4ed8;">-${formatNumber(sellerPayout)}원</td>
-            </tr>
-            <tr style="background: ${netProfit >= 0 ? '#dcfce7' : '#fee2e2'};">
-              <td style="padding: 12px 0; font-weight: 700; color: ${netProfit >= 0 ? '#166534' : '#dc2626'};">순이익</td>
-              <td style="padding: 12px 0; text-align: right; font-weight: 700; font-size: 18px; color: ${netProfit >= 0 ? '#166534' : '#dc2626'};">${formatNumber(netProfit)}원</td>
-            </tr>
-          </table>
-        </div>
 
         <div style="display: flex; gap: 8px; justify-content: flex-end;">
           <button onclick="closeModal()" class="btn btn-secondary" style="padding: 10px 20px; cursor: pointer;">닫기</button>
@@ -12818,7 +12796,7 @@ function generateManagementReport() {
         <!-- 헤더 -->
         <div style="text-align: center; margin-bottom: 32px; padding-bottom: 20px; border-bottom: 3px solid #f97316;">
           <h1 style="font-size: 28px; font-weight: 700; margin-bottom: 8px; color: #1f2937;">📊 정산 내역서</h1>
-          <p style="color: #6b7280; font-size: 14px;">모여라딜 | ${today}</p>
+          <p style="color: #6b7280; font-size: 14px;">${today}</p>
           <div style="margin-top: 12px; display: inline-block; background: var(--gray-100); color: var(--gray-600); padding: 8px 16px; border-radius: 8px; font-size: 14px; font-weight: 600;">
             ⏳ 정산대기 ${totalPendingCount}건
           </div>
@@ -13231,7 +13209,7 @@ async function downloadManagementReportExcel() {
   
   // ===== 시트1: 자사 상품 - 셀러 정산 =====
   const sheet1Data = [
-    ['📊 정산 내역서 - 모여라딜 | ' + today],
+    ['📊 정산 내역서 | ' + today],
     [],
     ['1. 자사 상품 - 셀러 정산 (' + sellerInhouse.length + '건)'],
     ['셀러명', '브랜드', '공구기간', '판매상품', '단가', '수량', '판매금액', '마진금액', '원천세', '소계', '총실지급액', '정산일']
@@ -13630,7 +13608,7 @@ function renderSalesReport() {
       <h1 style="font-size: 28px; font-weight: 700; color: var(--gray-900); margin: 0 0 8px; display: flex; align-items: center; justify-content: center; gap: 12px;">
         <span style="font-size: 32px;">📊</span> 정산 내역서
       </h1>
-      <p style="color: var(--gray-500); font-size: 14px; margin: 0 0 20px;">모여라딜 | ${todayStr}</p>
+      <p style="color: var(--gray-500); font-size: 14px; margin: 0 0 20px;">${todayStr}</p>
       <div style="display: flex; justify-content: center; gap: 12px; flex-wrap: wrap;">
         <button class="btn" style="background: #fef3c7; color: #92400e; border: 2px solid #f59e0b; font-weight: 700; padding: 10px 24px;" onclick="scrollToSection('pending-section')">
           ⏳ 정산대기 ${pendingCount}건
@@ -17974,7 +17952,7 @@ function generateSupplierInvoice(settlementId) {
         
         <!-- 푸터 -->
         <div style="margin-top: 32px; padding-top: 20px; border-top: 1px solid #e5e7eb; text-align: center; color: #9ca3af; font-size: 12px;">
-          <p>본 정산서는 모여라딜에서 발행되었습니다.</p>
+          <p>본 정산서의 내용은 정산 기준일 기준으로 작성되었습니다.</p>
           <p style="margin-top: 4px;">문의: moyeoradeal@gmail.com</p>
         </div>
       </div>
@@ -18710,7 +18688,7 @@ function generateSellerStatement(settlementId) {
       </table>
       
       <div style="text-align: center; margin-top: 40px; padding-top: 20px; border-top: 1px solid #e5e7eb;">
-        <p style="color: #6b7684; font-size: 13px;">본 정산서는 모여라딜에서 발행되었습니다.</p>
+        <p style="color: #6b7684; font-size: 13px;">본 정산서의 내용은 정산 기준일 기준으로 작성되었습니다.</p>
       </div>
     </div>
   `;
@@ -18857,7 +18835,7 @@ function generateSupplierStatement(settlementId) {
       </table>
       
       <div style="text-align: center; margin-top: 40px; padding-top: 20px; border-top: 1px solid #e5e7eb;">
-        <p style="color: #6b7684; font-size: 13px;">본 정산서는 모여라딜에서 발행되었습니다.</p>
+        <p style="color: #6b7684; font-size: 13px;">본 정산서의 내용은 정산 기준일 기준으로 작성되었습니다.</p>
       </div>
     </div>
   `;


### PR DESCRIPTION
1. 타사 상품 공급단가 자동계산: supplyPrice가 0이면 판매단가에서 마진율 빼서 자동 계산
   - 공급단가 = 판매단가 * (100 - 마진율) / 100
   - 공급사 정산 0원 문제 해결

2. 정산서에서 "모여라딜" 표시 제거
   - 정산 내역서 헤더에서 "모여라딜 |" 제거
   - 정산서 푸터 문구 변경
   - 엑셀 내보내기 헤더 수정
   - "모여라딜 정산" 섹션 제거 (공구별 정산서에서)