### PR TITLE
Improve product data management table UI

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -25880,12 +25880,15 @@ async function renderProductDataManager() {
     const dealProducts = [];
     deals.forEach(deal => {
       if (deal.selectedProducts && deal.selectedProducts.length > 0) {
+        const supplierInfo = suppliers.find(s => s.id === deal.supplierId);
         deal.selectedProducts.forEach(sp => {
           dealProducts.push({
             dealId: deal.id,
             dealTitle: deal.title || '',
             sellerId: deal.sellerId,
             sellerName: sellers.find(s => s.id === deal.sellerId)?.name || '',
+            supplierId: deal.supplierId || '',
+            supplierName: supplierInfo?.name || sp.brandName || '미지정',
             productName: sp.productName || sp.name || '',
             sku: sp.sku || sp.productName || '',
             supplyPrice: Number(sp.supplyPrice) || 0,
@@ -25990,26 +25993,46 @@ async function renderProductDataManager() {
         </div>
       </div>
 
+      <!-- 범례 -->
+      <div style="display: flex; gap: 16px; margin-bottom: 12px; flex-wrap: wrap; font-size: 12px;">
+        <div style="display: flex; align-items: center; gap: 6px;">
+          <span style="display: inline-block; width: 14px; height: 14px; background: #dbeafe; border-radius: 3px;"></span>
+          <span>카페24 주문데이터</span>
+        </div>
+        <div style="display: flex; align-items: center; gap: 6px;">
+          <span style="display: inline-block; width: 14px; height: 14px; background: #f0fdf4; border: 1px solid #22c55e; border-radius: 3px;"></span>
+          <span>공구DB 매칭</span>
+        </div>
+        <div style="display: flex; align-items: center; gap: 6px;">
+          <span style="display: inline-block; width: 14px; height: 14px; background: #fef3c7; border-radius: 3px;"></span>
+          <span>수정 가능 (정산서 반영)</span>
+        </div>
+        <div style="display: flex; align-items: center; gap: 6px;">
+          <span style="display: inline-block; width: 14px; height: 14px; border: 2px solid #3b82f6; border-radius: 3px;"></span>
+          <span style="font-weight: 600; color: #1d4ed8;">📋 정산서 반영 영역</span>
+        </div>
+      </div>
+
       <!-- 상품 테이블 -->
-      <div class="card">
+      <div class="card" style="border: 2px solid transparent; background: linear-gradient(white, white) padding-box, linear-gradient(90deg, transparent 0%, transparent 55%, #3b82f6 55%, #3b82f6 100%) border-box;">
         <div style="overflow-x: auto;">
           <table class="data-table" id="pdm-table">
             <thead>
               <tr style="background: var(--gray-50);">
-                <th style="width: 50px; text-align: center;">#</th>
-                <th style="width: 80px; text-align: center;">데이터<br>출처</th>
-                <th style="min-width: 100px;">셀러명</th>
-                <th style="min-width: 200px;">상품명<br>(카페24 주문)</th>
-                <th style="min-width: 180px; background: #f0fdf4;">공구 상품 SKU<br>(매칭)</th>
-                <th style="width: 80px; text-align: center;">구분</th>
-                <th style="width: 80px; text-align: right;">판매단가</th>
-                <th style="width: 60px; text-align: center;">수량</th>
-                <th style="width: 100px; text-align: right;">판매금액</th>
-                <th style="width: 100px; text-align: center; background: #fef3c7;">마진율(%)</th>
-                <th style="width: 120px; text-align: right; background: #fef3c7;">공급가(V+)</th>
-                <th style="width: 100px; text-align: right; background: #dcfce7;">마진금액</th>
-                <th style="width: 100px; text-align: right; background: #e0e7ff;">공급가액</th>
-                <th style="width: 80px; text-align: center;">상태</th>
+                <th style="width: 40px; text-align: center;">#</th>
+                <th style="width: 70px; text-align: center; background: #dbeafe;">출처</th>
+                <th style="min-width: 80px; background: #dbeafe;">셀러명<br><span style="font-size:9px;color:#6b7280;font-weight:400;">카페24</span></th>
+                <th style="min-width: 180px; background: #dbeafe;">상품명<br><span style="font-size:9px;color:#6b7280;font-weight:400;">카페24 주문</span></th>
+                <th style="min-width: 160px; background: #f0fdf4;">공구 SKU<br><span style="font-size:9px;color:#16a34a;font-weight:400;">공구DB 매칭</span></th>
+                <th style="min-width: 80px; background: #f0fdf4;">공급사<br><span style="font-size:9px;color:#16a34a;font-weight:400;">공구DB</span></th>
+                <th style="width: 60px; text-align: center; background: #dbeafe;">구분<br><span style="font-size:9px;color:#6b7280;font-weight:400;">카페24</span></th>
+                <th style="width: 70px; text-align: right; background: #dbeafe;">판매단가<br><span style="font-size:9px;color:#6b7280;font-weight:400;">카페24</span></th>
+                <th style="width: 50px; text-align: center; background: #dbeafe;">수량<br><span style="font-size:9px;color:#6b7280;font-weight:400;">카페24</span></th>
+                <th style="width: 90px; text-align: right; background: #dbeafe;">판매금액<br><span style="font-size:9px;color:#6b7280;font-weight:400;">카페24</span></th>
+                <th style="width: 80px; text-align: center; background: #fef3c7; border-left: 3px solid #3b82f6;">마진율(%)<br><span style="font-size:9px;color:#92400e;font-weight:400;">공구DB→정산</span></th>
+                <th style="width: 100px; text-align: right; background: #fef3c7;">공급가(V+)<br><span style="font-size:9px;color:#92400e;font-weight:400;">공구DB→정산</span></th>
+                <th style="width: 90px; text-align: right; background: #dcfce7;">마진금액<br><span style="font-size:9px;color:#166534;font-weight:400;">자동계산→정산</span></th>
+                <th style="width: 70px; text-align: center;">상태</th>
               </tr>
             </thead>
             <tbody id="pdm-tbody">
@@ -26077,55 +26100,56 @@ async function renderProductDataManager() {
 
                 // 자동 매칭 표시 스타일
                 const selectStyle = bestMatch
-                  ? 'width: 100%; font-size: 12px; border: 2px solid #22c55e; border-radius: 4px; padding: 4px; background: #f0fdf4;'
-                  : 'width: 100%; font-size: 12px; border: 1px solid #d1d5db; border-radius: 4px; padding: 4px;';
+                  ? 'width: 100%; font-size: 11px; border: 2px solid #22c55e; border-radius: 4px; padding: 3px; background: #f0fdf4;'
+                  : 'width: 100%; font-size: 11px; border: 1px solid #d1d5db; border-radius: 4px; padding: 3px;';
                 const autoMatchLabel = bestMatch
-                  ? '<div style="font-size: 10px; color: #16a34a; margin-top: 2px;">✓ 자동매칭</div>'
+                  ? '<div style="font-size: 9px; color: #16a34a; margin-top: 1px;">✓ 자동</div>'
                   : '';
+
+                // 공급사명 가져오기
+                const supplierName = bestMatch?.supplierName || '-';
 
                 return `
                   <tr data-idx="${idx}" data-key="${p.sellerName}___${p.productName}" data-type="${p.productType}">
-                    <td style="text-align: center; color: var(--gray-500);">${idx + 1}</td>
-                    <td style="text-align: center;">
-                      <span style="background: #dbeafe; color: #1d4ed8; padding: 2px 8px; border-radius: 10px; font-size: 11px;">
+                    <td style="text-align: center; color: var(--gray-500); font-size: 11px;">${idx + 1}</td>
+                    <td style="text-align: center; background: #eff6ff;">
+                      <span style="background: #dbeafe; color: #1d4ed8; padding: 2px 6px; border-radius: 8px; font-size: 10px;">
                         카페24
                       </span>
                     </td>
-                    <td style="font-weight: 600;">${p.sellerName}</td>
-                    <td style="font-size: 12px; max-width: 250px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;" title="${p.productName}">${p.productName}</td>
-                    <td style="background: #f9fafb;">
+                    <td style="font-weight: 600; font-size: 12px; background: #eff6ff;">${p.sellerName}</td>
+                    <td style="font-size: 11px; max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; background: #eff6ff;" title="${p.productName}">${p.productName}</td>
+                    <td style="background: #f0fdf4;">
                       <select class="pdm-deal-product-select" data-key="${p.sellerName}___${p.productName}"
                         style="${selectStyle}"
                         onchange="matchDealProduct(this)" ${sellerDealProducts.length === 0 ? 'disabled' : ''}>
                         ${dealProductOptions}
                       </select>
-                      ${sellerDealProducts.length === 0 ? '<div style="font-size: 11px; color: #9ca3af; margin-top: 2px;">공구 상품 없음</div>' : autoMatchLabel}
+                      ${sellerDealProducts.length === 0 ? '<div style="font-size: 9px; color: #9ca3af;">없음</div>' : autoMatchLabel}
                     </td>
-                    <td style="text-align: center;">
-                      <span style="background: ${p.productType === 'external' ? '#fef3c7' : '#dbeafe'}; color: ${p.productType === 'external' ? '#92400e' : '#1d4ed8'}; padding: 2px 8px; border-radius: 10px; font-size: 11px;">
+                    <td style="font-size: 11px; background: #f0fdf4; color: #166534;" class="pdm-supplier-name">${supplierName}</td>
+                    <td style="text-align: center; background: #eff6ff;">
+                      <span style="background: ${p.productType === 'external' ? '#fef3c7' : '#dbeafe'}; color: ${p.productType === 'external' ? '#92400e' : '#1d4ed8'}; padding: 2px 6px; border-radius: 8px; font-size: 10px;">
                         ${p.productType === 'external' ? '타사' : '자사'}
                       </span>
                     </td>
-                    <td style="text-align: right;">${p.unitPrice.toLocaleString()}원</td>
-                    <td style="text-align: center;">${p.quantity}</td>
-                    <td style="text-align: right; font-weight: 600;">${p.totalAmount.toLocaleString()}원</td>
-                    <td style="text-align: center; background: #fffbeb;">
+                    <td style="text-align: right; font-size: 11px; background: #eff6ff;">${p.unitPrice.toLocaleString()}</td>
+                    <td style="text-align: center; font-size: 11px; background: #eff6ff;">${p.quantity}</td>
+                    <td style="text-align: right; font-weight: 600; font-size: 11px; background: #eff6ff;">${p.totalAmount.toLocaleString()}</td>
+                    <td style="text-align: center; background: #fef3c7; border-left: 3px solid #3b82f6;">
                       <input type="number" class="pdm-margin-input" data-key="${p.sellerName}___${p.productName}"
                         value="${finalMargin}" step="0.1" min="0" max="100"
-                        style="width: 60px; text-align: center; border: 1px solid #e5e7eb; border-radius: 4px; padding: 4px;${bestMatch ? ' background: #dcfce7;' : ''}"
+                        style="width: 55px; text-align: center; border: 1px solid #e5e7eb; border-radius: 4px; padding: 3px; font-size: 11px;${bestMatch ? ' background: #dcfce7;' : ''}"
                         onchange="updateProductCalc(this)">
                     </td>
-                    <td style="text-align: right; background: #fffbeb;">
+                    <td style="text-align: right; background: #fef3c7;">
                       <input type="number" class="pdm-supply-input" data-key="${p.sellerName}___${p.productName}"
                         value="${finalSupply}" step="100" min="0"
-                        style="width: 90px; text-align: right; border: 1px solid #e5e7eb; border-radius: 4px; padding: 4px;${bestMatch ? ' background: #dcfce7;' : ''}"
+                        style="width: 80px; text-align: right; border: 1px solid #e5e7eb; border-radius: 4px; padding: 3px; font-size: 11px;${bestMatch ? ' background: #dcfce7;' : ''}"
                         onchange="updateProductCalc(this)" ${p.productType === 'inhouse' ? 'disabled placeholder="자사"' : ''}>
                     </td>
-                    <td style="text-align: right; background: #f0fdf4; font-weight: 500; color: #166534;" class="pdm-margin-amount">
-                      ${finalMarginAmount.toLocaleString()}원
-                    </td>
-                    <td style="text-align: right; background: #eef2ff; color: #4338ca;" class="pdm-supply-total">
-                      ${p.productType === 'external' ? finalSupplyTotal.toLocaleString() + '원' : '-'}
+                    <td style="text-align: right; background: #dcfce7; font-weight: 600; color: #166534; font-size: 11px;" class="pdm-margin-amount">
+                      ${finalMarginAmount.toLocaleString()}
                     </td>
                     <td style="text-align: center;">${finalStatusBadge}</td>
                   </tr>
@@ -26138,15 +26162,24 @@ async function renderProductDataManager() {
 
       <!-- 안내 -->
       <div style="margin-top: 16px; padding: 16px; background: #f0f9ff; border-radius: 12px; border-left: 4px solid #3b82f6;">
-        <div style="font-weight: 600; color: #1d4ed8; margin-bottom: 8px;">💡 사용 가이드</div>
-        <ul style="font-size: 13px; color: #1e40af; margin: 0; padding-left: 20px; line-height: 1.8;">
-          <li><strong>데이터 출처</strong>: 현재는 카페24 주문 데이터만 표시됩니다 (향후 공구 데이터도 추가 예정)</li>
-          <li><strong>공구 상품 SKU 매칭</strong>: 드롭다운에서 공구 상품을 선택하면 공급단가와 마진율이 자동으로 입력됩니다</li>
-          <li><strong>마진율(%)</strong>: 셀러에게 지급할 수수료율 (판매금액 × 마진율 = 마진금액)</li>
-          <li><strong>공급가(V+)</strong>: 타사 상품의 공급사 지급 단가 (부가세 포함)</li>
-          <li><strong>💾 전체 저장</strong>: 수정한 마진율/공급단가를 카페24 주문 데이터에 일괄 반영</li>
-          <li>저장 후 <strong>정산관리</strong>에서 정산서를 생성하면 여기서 설정한 값이 적용됩니다</li>
-        </ul>
+        <div style="font-weight: 600; color: #1d4ed8; margin-bottom: 8px;">💡 컬럼 설명</div>
+        <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 12px; font-size: 12px;">
+          <div style="background: #eff6ff; padding: 10px; border-radius: 8px;">
+            <div style="font-weight: 600; color: #1d4ed8; margin-bottom: 4px;">📦 카페24 데이터 (파란색)</div>
+            <div style="color: #4b5563;">셀러명, 상품명, 구분, 판매단가, 수량, 판매금액</div>
+            <div style="color: #6b7280; font-size: 11px; margin-top: 2px;">→ 카페24 주문에서 자동 수집</div>
+          </div>
+          <div style="background: #f0fdf4; padding: 10px; border-radius: 8px;">
+            <div style="font-weight: 600; color: #16a34a; margin-bottom: 4px;">🔗 공구DB 매칭 (초록색)</div>
+            <div style="color: #4b5563;">공구 SKU, 공급사</div>
+            <div style="color: #6b7280; font-size: 11px; margin-top: 2px;">→ 상품명 유사도로 자동매칭 (수동 변경 가능)</div>
+          </div>
+          <div style="background: #fef3c7; padding: 10px; border-radius: 8px; border: 2px solid #3b82f6;">
+            <div style="font-weight: 600; color: #92400e; margin-bottom: 4px;">📋 정산서 반영 (노란색+파란테두리)</div>
+            <div style="color: #4b5563;">마진율(%), 공급가(V+), 마진금액</div>
+            <div style="color: #6b7280; font-size: 11px; margin-top: 2px;">→ 공구DB에서 가져오며, 정산서 생성 시 사용</div>
+          </div>
+        </div>
       </div>
     `;
 
@@ -26270,22 +26303,23 @@ function matchDealProduct(select) {
   select.style.border = '2px solid #f59e0b';
   select.style.background = '#fefce8';
   const existingLabel = select.parentElement.querySelector('div');
-  if (existingLabel && existingLabel.textContent.includes('자동매칭')) {
-    existingLabel.textContent = '✎ 수동선택';
+  if (existingLabel && (existingLabel.textContent.includes('자동') || existingLabel.textContent.includes('수동'))) {
+    existingLabel.textContent = '✎ 수동';
     existingLabel.style.color = '#d97706';
+  }
+
+  // 공급사명 업데이트
+  const selectedSku = selectedOption.value;
+  const matchedDealProduct = window.pdmDealProducts?.find(dp => dp.sku === selectedSku);
+  const supplierNameCell = row.querySelector('.pdm-supplier-name');
+  if (supplierNameCell && matchedDealProduct) {
+    supplierNameCell.textContent = matchedDealProduct.supplierName || '-';
   }
 
   // 계산 업데이트
   const marginAmountCell = row.querySelector('.pdm-margin-amount');
-  const supplyTotalCell = row.querySelector('.pdm-supply-total');
-
   const marginAmount = Math.round(product.totalAmount * marginRate / 100);
-  marginAmountCell.textContent = marginAmount.toLocaleString() + '원';
-
-  if (product.productType === 'external') {
-    const supplyTotal = supplyPrice * product.quantity;
-    supplyTotalCell.textContent = supplyTotal.toLocaleString() + '원';
-  }
+  marginAmountCell.textContent = marginAmount.toLocaleString();
 
   // 상태 업데이트
   const statusCell = row.querySelector('td:last-child');


### PR DESCRIPTION
상품데이터관리 테이블 UI 개선:
- 공급사명 컬럼 추가 (공구DB에서 매칭)
- 각 컬럼에 데이터 출처 표시 (카페24, 공구DB, 정산서)
- 중복되는 공급가액 컬럼 제거
- 정산서 반영 영역 파란색 테두리로 구분
- 컬럼 설명 범례 추가
- 카페24 데이터: 파란 배경
- 공구DB 매칭: 초록 배경
- 정산서 반영: 노란 배경 + 파란 테두리