### PR TITLE
Fix SKU dropdown selection - show all products when no seller match

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -26044,10 +26044,23 @@ async function renderProductDataManager() {
                   ? '<span style="background:#dcfce7;color:#166534;padding:2px 8px;border-radius:10px;font-size:11px;">✓ 완료</span>'
                   : '<span style="background:#fee2e2;color:#dc2626;padding:2px 8px;border-radius:10px;font-size:11px;">⚠ 미완료</span>';
 
-                // 해당 셀러의 공구 상품 목록
-                const sellerDealProducts = dealProducts.filter(dp =>
-                  dp.sellerName.toLowerCase() === p.sellerName.toLowerCase()
-                );
+                // 해당 셀러의 공구 상품 목록 (유연한 매칭)
+                const normalizeSellerName = (name) => (name || '').toLowerCase().replace(/[^가-힣a-z0-9]/g, '');
+                const pSellerNorm = normalizeSellerName(p.sellerName);
+
+                let sellerDealProducts = dealProducts.filter(dp => {
+                  const dpSellerNorm = normalizeSellerName(dp.sellerName);
+                  // 정확한 매칭 또는 포함 관계
+                  return dpSellerNorm === pSellerNorm ||
+                         dpSellerNorm.includes(pSellerNorm) ||
+                         pSellerNorm.includes(dpSellerNorm);
+                });
+
+                // 매칭되는 상품이 없으면 전체 공구 상품 목록 제공
+                const showAllProducts = sellerDealProducts.length === 0;
+                if (showAllProducts) {
+                  sellerDealProducts = dealProducts;
+                }
 
                 // 상품명 유사도 계산 함수
                 const getSimilarity = (str1, str2) => {
@@ -26075,12 +26088,13 @@ async function renderProductDataManager() {
                 });
 
                 // 공구 상품 매칭 드롭다운 생성
-                let dealProductOptions = '<option value="">수동 선택...</option>';
+                let dealProductOptions = '<option value="">선택...</option>';
                 sellerDealProducts.forEach(dp => {
                   const isAutoMatched = bestMatch && dp.sku === bestMatch.sku;
                   const selected = isAutoMatched ? 'selected' : '';
-                  dealProductOptions += `<option value="${dp.sku}" data-supply="${dp.supplyPrice}" data-margin="${dp.marginRate}" ${selected}>
-                    ${dp.sku} (공급가: ${dp.supplyPrice.toLocaleString()}원)
+                  const sellerLabel = showAllProducts ? ` [${dp.sellerName}]` : '';
+                  dealProductOptions += `<option value="${dp.sku}" data-supply="${dp.supplyPrice}" data-margin="${dp.marginRate}" data-supplier="${dp.supplierName || ''}" ${selected}>
+                    ${dp.sku}${sellerLabel} (${dp.supplyPrice.toLocaleString()}원)
                   </option>`;
                 });
 
@@ -26102,9 +26116,15 @@ async function renderProductDataManager() {
                 const selectStyle = bestMatch
                   ? 'width: 100%; font-size: 11px; border: 2px solid #22c55e; border-radius: 4px; padding: 3px; background: #f0fdf4;'
                   : 'width: 100%; font-size: 11px; border: 1px solid #d1d5db; border-radius: 4px; padding: 3px;';
-                const autoMatchLabel = bestMatch
-                  ? '<div style="font-size: 9px; color: #16a34a; margin-top: 1px;">✓ 자동</div>'
-                  : '';
+
+                let autoMatchLabel = '';
+                if (sellerDealProducts.length === 0) {
+                  autoMatchLabel = '<div style="font-size: 9px; color: #9ca3af;">공구 없음</div>';
+                } else if (bestMatch) {
+                  autoMatchLabel = '<div style="font-size: 9px; color: #16a34a; margin-top: 1px;">✓ 자동</div>';
+                } else if (showAllProducts) {
+                  autoMatchLabel = '<div style="font-size: 9px; color: #f59e0b;">전체 목록</div>';
+                }
 
                 // 공급사명 가져오기
                 const supplierName = bestMatch?.supplierName || '-';
@@ -26122,10 +26142,10 @@ async function renderProductDataManager() {
                     <td style="background: #f0fdf4;">
                       <select class="pdm-deal-product-select" data-key="${p.sellerName}___${p.productName}"
                         style="${selectStyle}"
-                        onchange="matchDealProduct(this)" ${sellerDealProducts.length === 0 ? 'disabled' : ''}>
+                        onchange="matchDealProduct(this)" ${dealProducts.length === 0 ? 'disabled' : ''}>
                         ${dealProductOptions}
                       </select>
-                      ${sellerDealProducts.length === 0 ? '<div style="font-size: 9px; color: #9ca3af;">없음</div>' : autoMatchLabel}
+                      ${autoMatchLabel}
                     </td>
                     <td style="font-size: 11px; background: #f0fdf4; color: #166534;" class="pdm-supplier-name">${supplierName}</td>
                     <td style="text-align: center; background: #eff6ff;">
@@ -26309,11 +26329,12 @@ function matchDealProduct(select) {
   }
 
   // 공급사명 업데이트
+  const supplierNameFromOption = selectedOption.dataset.supplier || '';
   const selectedSku = selectedOption.value;
   const matchedDealProduct = window.pdmDealProducts?.find(dp => dp.sku === selectedSku);
   const supplierNameCell = row.querySelector('.pdm-supplier-name');
-  if (supplierNameCell && matchedDealProduct) {
-    supplierNameCell.textContent = matchedDealProduct.supplierName || '-';
+  if (supplierNameCell) {
+    supplierNameCell.textContent = supplierNameFromOption || matchedDealProduct?.supplierName || '-';
   }
 
   // 계산 업데이트


### PR DESCRIPTION
공구 SKU 드롭다운 선택 문제 해결:
- 셀러명 매칭을 더 유연하게 (특수문자 제거, 포함 관계 확인)
- 셀러 매칭 실패 시 전체 공구 상품 목록에서 선택 가능
- 전체 목록 표시 시 셀러명 함께 표시 [셀러명]
- '공구 없음', '전체 목록' 등 상태 레이블 추가