### PR TITLE
Change file upload to Base64 method (no Firebase Storage needed)

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -33997,12 +33997,12 @@ function openAddReferenceModal(refId) {
     '<div style="font-size: 11px; color: #6B7684; margin-top: 6px;">유튜브, 인스타그램, 웹사이트 등 외부 링크</div></div>' +
 
     '<div style="background: linear-gradient(135deg, #FEF3C7, #FDE68A); padding: 16px; border-radius: 10px; border: 1px solid #F59E0B;">' +
-    '<label style="display: block; font-size: 13px; font-weight: 600; margin-bottom: 10px; color: #B45309;">📤 파일 직접 업로드</label>' +
+    '<label style="display: block; font-size: 13px; font-weight: 600; margin-bottom: 10px; color: #B45309;">📤 이미지 직접 업로드</label>' +
     '<div id="ref-file-upload-area" style="background: white; border: 2px dashed #F59E0B; border-radius: 10px; padding: 20px; text-align: center; cursor: pointer; transition: all 0.2s;" onclick="document.getElementById(\'ref-file-input\').click()" onmouseover="this.style.borderColor=\'#D97706\'; this.style.background=\'#FFFBEB\'" onmouseout="this.style.borderColor=\'#F59E0B\'; this.style.background=\'white\'">' +
-    '<input type="file" id="ref-file-input" accept=".jpg,.jpeg,.png,.gif,.mp4" style="display: none;" onchange="handleReferenceFileUpload(this.files[0])" />' +
+    '<input type="file" id="ref-file-input" accept=".jpg,.jpeg,.png,.gif" style="display: none;" onchange="handleReferenceFileUpload(this.files[0])" />' +
     '<div style="font-size: 32px; margin-bottom: 8px;">🖼️</div>' +
-    '<div style="font-size: 14px; font-weight: 600; color: #92400E;">클릭하여 파일 선택</div>' +
-    '<div style="font-size: 12px; color: #B45309; margin-top: 4px;">JPG, PNG, GIF, MP4 (최대 20MB)</div></div>' +
+    '<div style="font-size: 14px; font-weight: 600; color: #92400E;">클릭하여 이미지 선택</div>' +
+    '<div style="font-size: 12px; color: #B45309; margin-top: 4px;">JPG, PNG, GIF (자동 압축)</div></div>' +
     '<div id="ref-file-preview" style="display: none; margin-top: 12px; padding: 12px; background: white; border-radius: 8px; border: 1px solid #F59E0B;"></div></div>' +
 
     '<div style="background: #DCFCE7; padding: 16px; border-radius: 10px;">' +
@@ -34018,23 +34018,32 @@ function openAddReferenceModal(refId) {
   if (refId) loadReferenceForEdit(refId);
 }
 
-// 레퍼런스 파일 업로드 처리
+// 레퍼런스 파일 업로드 처리 (Base64 방식 - Firestore 직접 저장)
 async function handleReferenceFileUpload(file) {
   if (!file) return;
 
-  // 파일 크기 제한 (20MB)
-  if (file.size > 20 * 1024 * 1024) {
-    showToast('파일 크기는 20MB 이하여야 합니다');
+  var ext = file.name.split('.').pop().toLowerCase();
+  var isVideo = file.type.startsWith('video/') || ext === 'mp4';
+  var isGif = file.type === 'image/gif' || ext === 'gif';
+
+  // 동영상은 용량이 커서 Base64 저장 불가
+  if (isVideo) {
+    showToast('동영상은 외부 링크로만 등록 가능합니다 (용량 제한)');
+    return;
+  }
+
+  // 파일 크기 제한 (원본 10MB)
+  if (file.size > 10 * 1024 * 1024) {
+    showToast('파일 크기는 10MB 이하여야 합니다');
     return;
   }
 
   // 허용 파일 타입 검사
-  var allowedTypes = ['image/jpeg', 'image/png', 'image/gif', 'video/mp4'];
-  var allowedExts = ['jpg', 'jpeg', 'png', 'gif', 'mp4'];
-  var ext = file.name.split('.').pop().toLowerCase();
+  var allowedTypes = ['image/jpeg', 'image/png', 'image/gif'];
+  var allowedExts = ['jpg', 'jpeg', 'png', 'gif'];
 
   if (!allowedTypes.includes(file.type) && !allowedExts.includes(ext)) {
-    showToast('JPG, PNG, GIF, MP4 파일만 업로드 가능합니다');
+    showToast('JPG, PNG, GIF 파일만 업로드 가능합니다');
     return;
   }
 
@@ -34042,81 +34051,121 @@ async function handleReferenceFileUpload(file) {
   var previewDiv = document.getElementById('ref-file-preview');
   var saveBtn = document.getElementById('btn-save-ref');
 
-  // 업로드 중 UI
+  // 처리 중 UI
   uploadArea.innerHTML = '<div style="font-size: 32px; margin-bottom: 8px;">⏳</div>' +
-    '<div style="font-size: 14px; font-weight: 600; color: #92400E;">업로드 중...</div>' +
-    '<div id="ref-upload-progress" style="font-size: 12px; color: #B45309; margin-top: 4px;">0%</div>';
+    '<div style="font-size: 14px; font-weight: 600; color: #92400E;">이미지 처리 중...</div>' +
+    '<div style="font-size: 12px; color: #B45309; margin-top: 4px;">압축 및 변환 중</div>';
   uploadArea.style.pointerEvents = 'none';
   if (saveBtn) saveBtn.disabled = true;
 
   try {
-    var storageRef = firebase.storage().ref();
-    var fileName = Date.now() + '_' + file.name.replace(/[^a-zA-Z0-9._-]/g, '_');
-    var fileRef = storageRef.child('references/' + fileName);
+    var base64Data;
 
-    // 업로드 진행률 표시
-    var uploadTask = fileRef.put(file);
+    // GIF는 압축하지 않고 그대로 저장 (애니메이션 유지)
+    if (isGif) {
+      base64Data = await readFileAsBase64ForRef(file);
+    } else {
+      // JPG, PNG는 압축
+      base64Data = await compressImageForRef(file, 1200, 0.8);
+    }
 
-    uploadTask.on('state_changed',
-      function(snapshot) {
-        var progress = Math.round((snapshot.bytesTransferred / snapshot.totalBytes) * 100);
-        var progressEl = document.getElementById('ref-upload-progress');
-        if (progressEl) progressEl.textContent = progress + '%';
-      },
-      function(error) {
-        console.error('업로드 오류:', error);
-        showToast('파일 업로드 실패: ' + error.message);
+    // Firestore 문서 크기 제한 확인 (약 900KB)
+    if (base64Data.length > 900000) {
+      // 더 강하게 압축 시도
+      if (!isGif) {
+        base64Data = await compressImageForRef(file, 800, 0.6);
+      }
+
+      if (base64Data.length > 900000) {
+        showToast('이미지가 너무 큽니다. 더 작은 이미지를 사용해주세요.');
         resetRefUploadArea();
         if (saveBtn) saveBtn.disabled = false;
-      },
-      async function() {
-        // 업로드 완료
-        var downloadUrl = await uploadTask.snapshot.ref.getDownloadURL();
-        window.refUploadedFileUrl = downloadUrl;
-        window.refUploadedFileName = file.name;
-
-        // 미리보기 표시
-        var isVideo = file.type.startsWith('video/') || ext === 'mp4';
-        var isGif = file.type === 'image/gif' || ext === 'gif';
-        var previewHtml = '';
-
-        if (isVideo) {
-          previewHtml = '<div style="display: flex; align-items: center; gap: 12px;">' +
-            '<video src="' + downloadUrl + '" style="max-width: 120px; max-height: 80px; border-radius: 6px;" controls></video>' +
-            '<div style="flex: 1;">' +
-            '<div style="font-size: 13px; font-weight: 600; color: #92400E;">🎬 ' + file.name + '</div>' +
-            '<div style="font-size: 11px; color: #B45309; margin-top: 2px;">' + formatFileSize(file.size) + '</div></div>' +
-            '<button onclick="removeRefUploadedFile()" style="background: #FEE2E2; color: #DC2626; border: none; padding: 6px 12px; border-radius: 6px; cursor: pointer; font-size: 12px;">삭제</button></div>';
-        } else {
-          previewHtml = '<div style="display: flex; align-items: center; gap: 12px;">' +
-            '<img src="' + downloadUrl + '" style="max-width: 80px; max-height: 80px; border-radius: 6px; object-fit: cover;" />' +
-            '<div style="flex: 1;">' +
-            '<div style="font-size: 13px; font-weight: 600; color: #92400E;">' + (isGif ? '🎞️ ' : '🖼️ ') + file.name + '</div>' +
-            '<div style="font-size: 11px; color: #B45309; margin-top: 2px;">' + formatFileSize(file.size) + '</div></div>' +
-            '<button onclick="removeRefUploadedFile()" style="background: #FEE2E2; color: #DC2626; border: none; padding: 6px 12px; border-radius: 6px; cursor: pointer; font-size: 12px;">삭제</button></div>';
-        }
-
-        previewDiv.innerHTML = previewHtml;
-        previewDiv.style.display = 'block';
-
-        // 업로드 영역 완료 상태
-        uploadArea.innerHTML = '<div style="font-size: 32px; margin-bottom: 8px;">✅</div>' +
-          '<div style="font-size: 14px; font-weight: 600; color: #16A34A;">업로드 완료!</div>' +
-          '<div style="font-size: 12px; color: #6B7684; margin-top: 4px;">다른 파일을 선택하려면 클릭하세요</div>';
-        uploadArea.style.pointerEvents = 'auto';
-        uploadArea.onclick = function() { document.getElementById('ref-file-input').click(); };
-
-        if (saveBtn) saveBtn.disabled = false;
-        showToast('✅ 파일이 업로드되었습니다');
+        return;
       }
-    );
+    }
+
+    // 저장
+    window.refUploadedFileUrl = base64Data;
+    window.refUploadedFileName = file.name;
+    window.refUploadedFileType = file.type || 'image/' + ext;
+
+    // 미리보기 표시
+    var previewHtml = '<div style="display: flex; align-items: center; gap: 12px;">' +
+      '<img src="' + base64Data + '" style="max-width: 80px; max-height: 80px; border-radius: 6px; object-fit: cover;" />' +
+      '<div style="flex: 1;">' +
+      '<div style="font-size: 13px; font-weight: 600; color: #92400E;">' + (isGif ? '🎞️ ' : '🖼️ ') + file.name + '</div>' +
+      '<div style="font-size: 11px; color: #B45309; margin-top: 2px;">압축됨: ' + formatFileSize(base64Data.length * 0.75) + '</div></div>' +
+      '<button onclick="removeRefUploadedFile()" style="background: #FEE2E2; color: #DC2626; border: none; padding: 6px 12px; border-radius: 6px; cursor: pointer; font-size: 12px;">삭제</button></div>';
+
+    previewDiv.innerHTML = previewHtml;
+    previewDiv.style.display = 'block';
+
+    // 업로드 영역 완료 상태
+    uploadArea.innerHTML = '<div style="font-size: 32px; margin-bottom: 8px;">✅</div>' +
+      '<div style="font-size: 14px; font-weight: 600; color: #16A34A;">이미지 준비 완료!</div>' +
+      '<div style="font-size: 12px; color: #6B7684; margin-top: 4px;">다른 파일을 선택하려면 클릭하세요</div>';
+    uploadArea.style.pointerEvents = 'auto';
+    uploadArea.onclick = function() { document.getElementById('ref-file-input').click(); };
+
+    if (saveBtn) saveBtn.disabled = false;
+    showToast('✅ 이미지가 준비되었습니다');
 
   } catch (error) {
-    console.error('업로드 오류:', error);
-    showToast('파일 업로드 실패');
+    console.error('이미지 처리 오류:', error);
+    showToast('이미지 처리 실패: ' + (error.message || '알 수 없는 오류'));
     resetRefUploadArea();
     if (saveBtn) saveBtn.disabled = false;
   }
+}
+
+// 이미지 압축 함수
+function compressImageForRef(file, maxSize, quality) {
+  return new Promise(function(resolve, reject) {
+    var reader = new FileReader();
+    reader.onload = function(e) {
+      var img = new Image();
+      img.onload = function() {
+        var canvas = document.createElement('canvas');
+        var width = img.width;
+        var height = img.height;
+
+        // 리사이즈
+        if (width > maxSize || height > maxSize) {
+          if (width > height) {
+            height = Math.round(height * maxSize / width);
+            width = maxSize;
+          } else {
+            width = Math.round(width * maxSize / height);
+            height = maxSize;
+          }
+        }
+
+        canvas.width = width;
+        canvas.height = height;
+
+        var ctx = canvas.getContext('2d');
+        ctx.drawImage(img, 0, 0, width, height);
+
+        // JPEG로 압축
+        var compressedData = canvas.toDataURL('image/jpeg', quality);
+        resolve(compressedData);
+      };
+      img.onerror = reject;
+      img.src = e.target.result;
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+
+// 파일을 Base64로 읽기
+function readFileAsBase64ForRef(file) {
+  return new Promise(function(resolve, reject) {
+    var reader = new FileReader();
+    reader.onload = function(e) { resolve(e.target.result); };
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
 }
 
 // 파일 크기 포맷
@@ -34130,10 +34179,10 @@ function formatFileSize(bytes) {
 function resetRefUploadArea() {
   var uploadArea = document.getElementById('ref-file-upload-area');
   if (uploadArea) {
-    uploadArea.innerHTML = '<input type="file" id="ref-file-input" accept=".jpg,.jpeg,.png,.gif,.mp4" style="display: none;" onchange="handleReferenceFileUpload(this.files[0])" />' +
+    uploadArea.innerHTML = '<input type="file" id="ref-file-input" accept=".jpg,.jpeg,.png,.gif" style="display: none;" onchange="handleReferenceFileUpload(this.files[0])" />' +
       '<div style="font-size: 32px; margin-bottom: 8px;">🖼️</div>' +
-      '<div style="font-size: 14px; font-weight: 600; color: #92400E;">클릭하여 파일 선택</div>' +
-      '<div style="font-size: 12px; color: #B45309; margin-top: 4px;">JPG, PNG, GIF, MP4 (최대 20MB)</div>';
+      '<div style="font-size: 14px; font-weight: 600; color: #92400E;">클릭하여 이미지 선택</div>' +
+      '<div style="font-size: 12px; color: #B45309; margin-top: 4px;">JPG, PNG, GIF (자동 압축)</div>';
     uploadArea.style.pointerEvents = 'auto';
     uploadArea.onclick = function() { document.getElementById('ref-file-input').click(); };
   }


### PR DESCRIPTION
- Remove Firebase Storage dependency for reference uploads
- Compress images client-side (max 1200px, 80% quality)
- Store images as Base64 in Firestore directly
- Support JPG, PNG, GIF (MP4 requires external link)
- Auto re-compress if file too large (800px, 60% quality)
- GIF preserved without compression for animation