### PR TITLE
Refactor: 카페24 정산 메뉴 구조 재정리 - 데이터 흐름 기반

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -1881,16 +1881,13 @@
             </div>
             <div id="deal-submenu" style="display: block; padding-left: 8px;">
               <div class="nav-item active" data-tab="calendar" onclick="switchTab('calendar')" style="font-size: 13px;">
-                <span>캘린더</span>
+                <span>📅 캘린더</span>
               </div>
               <div class="nav-item" data-tab="dealManagement" onclick="switchTab('dealManagement')" style="font-size: 13px;">
-                <span>공구 현황/체크리스트</span>
+                <span>✅ 공구 현황/체크리스트</span>
               </div>
               <div class="nav-item" data-tab="dealCenter" onclick="switchTab('dealCenter')" style="font-size: 13px;">
-                <span>공구 제안 관리</span>
-              </div>
-              <div class="nav-item" data-tab="settlement" onclick="switchTab('settlement')" style="font-size: 13px;">
-                <span>정산 관리</span>
+                <span>💡 공구 제안 관리</span>
               </div>
             </div>
           </div>
@@ -1955,37 +1952,36 @@
             </div>
           </div>
           
-          <!-- 카페24 주문 공유 섹션 (파트너용) -->
+          <!-- 카페24 주문 공유 섹션 (파트너용 - 읽기 전용) -->
           <div class="nav-section">
-            <div class="nav-label" style="cursor: pointer; display: flex; align-items: center; justify-content: space-between; background: linear-gradient(135deg, #2563eb, #3b82f6); padding: 10px 14px; border-radius: 8px; margin-bottom: 4px; box-shadow: 0 2px 8px rgba(37, 99, 235, 0.3);" onclick="toggleCafe24Menu()">
+            <div class="nav-label" style="cursor: pointer; display: flex; align-items: center; justify-content: space-between; background: linear-gradient(135deg, #2563eb, #3b82f6); padding: 10px 14px; border-radius: 8px; box-shadow: 0 2px 8px rgba(37, 99, 235, 0.3);" onclick="switchTab('orderStatus')">
               <span style="font-weight: 600; color: white;">🛒 카페24 주문 공유 <span style="background: rgba(254, 243, 199, 0.9); color: #92400e; padding: 2px 6px; border-radius: 4px; font-size: 10px; margin-left: 4px;">파트너용</span></span>
-              <span id="cafe24-menu-arrow" style="transition: transform 0.2s; color: white; transform: rotate(180deg);">▼</span>
-            </div>
-            <div id="cafe24-submenu" style="display: block; padding-left: 8px;">
-              <div class="nav-item" data-tab="orderStatus" onclick="switchTab('orderStatus')" style="font-size: 13px;">
-                <span>📋 주문현황</span>
-              </div>
-              <div class="nav-item" data-tab="productDataManager" onclick="switchTab('productDataManager')" style="font-size: 13px;">
-                <span>📋 상품 데이터 관리</span>
-              </div>
+              <span style="color: rgba(255,255,255,0.7);">→</span>
             </div>
           </div>
 
-          <!-- 카페24 정산 섹션 (정산서용) -->
+          <!-- 💰 카페24 정산 섹션 (내부 정산 작업 전용) -->
           <div class="nav-section" style="margin-top: 12px;">
             <div class="nav-label" style="cursor: pointer; display: flex; align-items: center; justify-content: space-between; background: linear-gradient(135deg, #059669, #10b981); padding: 10px 14px; border-radius: 8px; margin-bottom: 4px; box-shadow: 0 2px 8px rgba(5, 150, 105, 0.3);" onclick="toggleCafe24SettlementMenu()">
-              <span style="font-weight: 600; color: white;">📊 카페24 정산 <span style="background: rgba(254, 243, 199, 0.9); color: #92400e; padding: 2px 6px; border-radius: 4px; font-size: 10px; margin-left: 4px;">정산서용</span></span>
+              <span style="font-weight: 600; color: white;">💰 카페24 정산 <span style="background: rgba(254, 243, 199, 0.9); color: #92400e; padding: 2px 6px; border-radius: 4px; font-size: 10px; margin-left: 4px;">정산서용</span></span>
               <span id="cafe24-settlement-menu-arrow" style="transition: transform 0.2s; color: white; transform: rotate(180deg);">▼</span>
             </div>
             <div id="cafe24-settlement-submenu" style="display: block; padding-left: 8px;">
               <div class="nav-item" onclick="openCafe24MappingModal()" style="font-size: 13px;">
-                <span>📤 엑셀 업로드 & 매핑</span>
+                <span>1️⃣ 엑셀 업로드 & 매핑</span>
               </div>
               <div class="nav-item" data-tab="cafe24Orders" onclick="switchTab('cafe24Orders')" style="font-size: 13px;">
-                <span>📦 주문 관리</span>
+                <span>2️⃣ 주문 관리</span>
               </div>
+              <div class="nav-item" data-tab="productDataManager" onclick="switchTab('productDataManager')" style="font-size: 13px;">
+                <span>3️⃣ 상품 데이터 관리</span>
+              </div>
+              <div class="nav-item" data-tab="settlement" onclick="switchTab('settlement')" style="font-size: 13px;">
+                <span>4️⃣ 정산서 생성 & 관리</span>
+              </div>
+              <div style="border-top: 1px dashed rgba(255,255,255,0.2); margin: 8px 0;"></div>
               <div class="nav-item" data-tab="cafe24SettlementData" onclick="switchTab('cafe24SettlementData')" style="font-size: 13px;">
-                <span>📋 정산 데이터 현황</span>
+                <span>📊 정산 데이터 현황</span>
               </div>
               <div class="nav-item" data-tab="cafe24Rankings" onclick="switchTab('cafe24Rankings')" style="font-size: 13px;">
                 <span>🏆 셀러/공급사 순위</span>


### PR DESCRIPTION
비즈니스 요구사항:
- 넷폼알앤디(모회사) 내 모여라딜(자회사) 운영
- 자사/타사 제품 회계 분리 필요
- 정산서 생성 프로세스 명확화

주요 변경사항:
1. 공구센터 정리
   - "정산 관리" 제거 → 카페24 정산으로 이동
   - 공구 기획/진행에 집중

2. 카페24 주문 공유 단순화
   - "상품 데이터 관리" 제거 → 카페24 정산으로 이동
   - 단일 버튼으로 변경 (파트너용 읽기 전용)

3. 💰 카페24 정산 메뉴 확장 (데이터 흐름 순서)
   1️⃣ 엑셀 업로드 & 매핑
   2️⃣ 주문 관리 (cafe24_orders 확인)
   3️⃣ 상품 데이터 관리 ⭐ (카페24+공구+공급사 매핑)
   4️⃣ 정산서 생성 & 관리 ⭐ (sellerSettlements/supplierSettlements 생성)
   ─────────────
   📊 정산 데이터 현황
   🏆 셀러/공급사 순위

효과:
- 정산 작업 프로세스가 메뉴 순서와 일치
- 카페24 데이터 → 정산서 생성 흐름 명확화
- 파트너 포털 연동 유지 (sellerSettlements 컬렉션)