### PR TITLE
영업현황 대시보드 정리 - 중복 섹션 제거 및 간소화

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -22282,203 +22282,72 @@ function renderSalesDashboardContent() {
     <div style="background: ${C.gray50}; min-height: 100vh; margin: -24px; padding: 24px;">
 
       <!-- 헤더 -->
-      <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 24px;">
+      <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
         <div>
-          <h1 style="font-size: 26px; font-weight: 700; color: ${C.black}; margin: 0;">영업현황</h1>
-          <p style="color: ${C.gray500}; margin-top: 6px; font-size: 14px;">${currentYear}년 목표 달성 현황 · 전략기획 연동</p>
+          <h1 style="font-size: 24px; font-weight: 700; color: ${C.black}; margin: 0;">영업현황</h1>
+          <p style="color: ${C.gray500}; margin-top: 4px; font-size: 13px;">
+            연 ${(T.annualRevenue / 100000000)}억 = 공구 ${T.requiredTotalDeals}건 (월${T.monthlyRequiredDeals}/주${T.weeklyRequiredDeals}) → 성공 ${T.targetSuccessDeals}건
+          </p>
         </div>
-        <div style="display: flex; gap: 10px;">
-          ${isAdmin ? `
-          <button onclick="openGoalCalculator()" style="padding: 10px 18px; font-size: 13px; font-weight: 600; background: ${C.white}; color: ${C.blue}; border: 1px solid ${C.gray200}; border-radius: 10px; cursor: pointer;">
-            🧮 공구설계 계산기
-          </button>
-          ` : ''}
-        </div>
-      </div>
-
-      <!-- 📋 전략기획 연동 설명 -->
-      <div style="background: ${C.white}; border: 2px solid ${C.primary}; border-radius: 12px; padding: 16px 20px; margin-bottom: 16px;">
-        <div style="display: flex; align-items: center; gap: 12px;">
-          <div style="background: ${C.primary}; color: white; padding: 6px 12px; border-radius: 6px; font-size: 12px; font-weight: 700;">전략기획 연동</div>
-          <div style="font-size: 14px; color: ${C.gray700};">
-            <strong>연 매출 ${(T.annualRevenue / 100000000).toFixed(0)}억 달성</strong> = 성공 공구 <strong>${T.targetSuccessDeals}건</strong> 필요
-            → 성공률 ${T.successRate}% 반영 시 <strong style="color: ${C.primary};">전체 ${T.requiredTotalDeals}건 공구 필요</strong>
-            (월 ${T.monthlyRequiredDeals}건, 주 ${T.weeklyRequiredDeals}건)
-          </div>
+        <div style="display: flex; gap: 8px;">
+          ${isAdmin ? `<button onclick="openGoalCalculator()" style="padding: 8px 14px; font-size: 12px; font-weight: 600; background: ${C.white}; color: ${C.blue}; border: 1px solid ${C.gray200}; border-radius: 8px; cursor: pointer;">🧮 계산기</button>` : ''}
+          <a href="#" onclick="event.preventDefault(); switchTab('guide'); guideTab='pipeline'; renderGuide();" style="padding: 8px 14px; font-size: 12px; font-weight: 600; background: ${C.primary}; color: white; border-radius: 8px; text-decoration: none;">📋 파이프라인 가이드</a>
         </div>
       </div>
 
-      <!-- 🎯 전략 목표 및 남은 기간 -->
-      <div style="background: linear-gradient(135deg, ${C.primary}, #e08600); border-radius: 16px; padding: 20px 24px; margin-bottom: 20px; color: white;">
-        <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 16px;">
-          <div>
-            <div style="font-size: 13px; opacity: 0.9; margin-bottom: 4px;">🎯 ${currentYear}년 목표 진행 현황</div>
-            <div style="font-size: 20px; font-weight: 700;">
-              공구 ${yearDeals.length}/${T.requiredTotalDeals}건 (${totalDealsProgress}%) ·
-              성공 ${successfulDeals.length}/${T.targetSuccessDeals}건 ·
-              매출 ${(totalSalesAmount / 100000000).toFixed(1)}/${(T.annualRevenue / 100000000)}억
-            </div>
+      <!-- 🎯 핵심 현황 배너 -->
+      <div style="background: linear-gradient(135deg, ${C.primary}, #e08600); border-radius: 14px; padding: 16px 20px; margin-bottom: 16px; color: white;">
+        <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 12px;">
+          <div style="display: flex; gap: 20px; flex-wrap: wrap;">
+            <div><div style="font-size: 11px; opacity: 0.85;">공구</div><div style="font-size: 20px; font-weight: 700;">${yearDeals.length}<span style="font-size: 13px; opacity: 0.8;">/${T.requiredTotalDeals}</span></div></div>
+            <div><div style="font-size: 11px; opacity: 0.85;">성공</div><div style="font-size: 20px; font-weight: 700;">${successfulDeals.length}<span style="font-size: 13px; opacity: 0.8;">/${T.targetSuccessDeals}</span></div></div>
+            <div><div style="font-size: 11px; opacity: 0.85;">매출</div><div style="font-size: 20px; font-weight: 700;">${(totalSalesAmount / 100000000).toFixed(1)}<span style="font-size: 13px; opacity: 0.8;">/${(T.annualRevenue / 100000000)}억</span></div></div>
+            <div><div style="font-size: 11px; opacity: 0.85;">성공률</div><div style="font-size: 20px; font-weight: 700;">${currentSuccessRate}%</div></div>
           </div>
           <div style="text-align: right;">
-            <div style="font-size: 12px; opacity: 0.8;">남은 기간</div>
-            <div style="font-size: 24px; font-weight: 700;">${remainingMonths}개월 ${remainingDays % 30}일</div>
+            <div style="font-size: 11px; opacity: 0.8;">남은 기간</div>
+            <div style="font-size: 18px; font-weight: 700;">${remainingMonths}개월 ${remainingDays % 30}일</div>
           </div>
         </div>
       </div>
 
-      <!-- 📊 핵심 KPI 그리드 -->
-      <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin-bottom: 20px;">
-
+      <!-- 📊 KPI + 주간/월간 통합 -->
+      <div style="display: grid; grid-template-columns: repeat(6, 1fr); gap: 12px; margin-bottom: 16px;">
         <!-- 연 매출 -->
-        <div style="background: ${C.white}; border-radius: 16px; padding: 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
-          <div style="display: flex; justify-content: space-between; align-items: start; margin-bottom: 12px;">
-            <div style="font-size: 13px; color: ${C.gray500};">연 매출</div>
-            <div style="font-size: 12px; font-weight: 600; color: ${getProgressColor(revenueProgress)};">${revenueProgress}%</div>
-          </div>
-          <div style="font-size: 24px; font-weight: 700; color: ${C.black}; margin-bottom: 4px;">${(totalSalesAmount / 100000000).toFixed(2)}억</div>
-          <div style="font-size: 12px; color: ${C.gray400};">목표 ${(T.annualRevenue / 100000000)}억</div>
-          <div style="background: ${C.gray100}; height: 6px; border-radius: 3px; margin-top: 12px; overflow: hidden;">
-            <div style="background: ${getProgressColor(revenueProgress)}; height: 100%; width: ${revenueProgress}%; border-radius: 3px; transition: width 0.3s;"></div>
-          </div>
+        <div style="background: ${C.white}; border-radius: 12px; padding: 14px; box-shadow: 0 1px 4px rgba(0,0,0,0.04);">
+          <div style="font-size: 11px; color: ${C.gray500}; margin-bottom: 6px;">연 매출</div>
+          <div style="font-size: 20px; font-weight: 700; color: ${C.black};">${(totalSalesAmount / 100000000).toFixed(2)}억</div>
+          <div style="background: ${C.gray100}; height: 4px; border-radius: 2px; margin-top: 8px;"><div style="background: ${getProgressColor(revenueProgress)}; height: 100%; width: ${revenueProgress}%; border-radius: 2px;"></div></div>
         </div>
-
         <!-- 연 순익 -->
-        <div style="background: ${C.white}; border-radius: 16px; padding: 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
-          <div style="display: flex; justify-content: space-between; align-items: start; margin-bottom: 12px;">
-            <div style="font-size: 13px; color: ${C.gray500};">연 순익</div>
-            <div style="font-size: 12px; font-weight: 600; color: ${getProgressColor(profitProgress)};">${profitProgress}%</div>
-          </div>
-          <div style="font-size: 24px; font-weight: 700; color: ${C.green}; margin-bottom: 4px;">${formatNumber(totalProfitAmount)}원</div>
-          <div style="font-size: 12px; color: ${C.gray400};">목표 ${formatNumber(T.annualProfit)}원</div>
-          <div style="background: ${C.gray100}; height: 6px; border-radius: 3px; margin-top: 12px; overflow: hidden;">
-            <div style="background: ${getProgressColor(profitProgress)}; height: 100%; width: ${profitProgress}%; border-radius: 3px;"></div>
-          </div>
+        <div style="background: ${C.white}; border-radius: 12px; padding: 14px; box-shadow: 0 1px 4px rgba(0,0,0,0.04);">
+          <div style="font-size: 11px; color: ${C.gray500}; margin-bottom: 6px;">연 순익</div>
+          <div style="font-size: 20px; font-weight: 700; color: ${C.green};">${formatNumber(totalProfitAmount)}원</div>
+          <div style="background: ${C.gray100}; height: 4px; border-radius: 2px; margin-top: 8px;"><div style="background: ${getProgressColor(profitProgress)}; height: 100%; width: ${profitProgress}%; border-radius: 2px;"></div></div>
         </div>
-
-        <!-- 공구 진행 (핵심 행동 목표) -->
-        <div style="background: ${C.white}; border-radius: 16px; padding: 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
-          <div style="display: flex; justify-content: space-between; align-items: start; margin-bottom: 12px;">
-            <div style="font-size: 13px; color: ${C.gray500};">공구 진행</div>
-            <div style="font-size: 12px; font-weight: 600; color: ${getProgressColor(totalDealsProgress)};">${totalDealsProgress}%</div>
-          </div>
-          <div style="font-size: 24px; font-weight: 700; color: ${C.black}; margin-bottom: 4px;">${yearDeals.length}건</div>
-          <div style="font-size: 12px; color: ${C.gray400};">목표 ${T.requiredTotalDeals}건 (성공 ${successfulDeals.length}/${T.targetSuccessDeals}건)</div>
-          <div style="background: ${C.gray100}; height: 6px; border-radius: 3px; margin-top: 12px; overflow: hidden;">
-            <div style="background: ${getProgressColor(totalDealsProgress)}; height: 100%; width: ${totalDealsProgress}%; border-radius: 3px;"></div>
-          </div>
+        <!-- 이번 주 -->
+        <div style="background: ${weeklyProgress >= 100 ? C.greenLight : C.blueLight}; border-radius: 12px; padding: 14px;">
+          <div style="font-size: 11px; color: ${C.gray600}; margin-bottom: 6px;">📅 이번 주</div>
+          <div style="font-size: 20px; font-weight: 700; color: ${weeklyProgress >= 100 ? C.green : C.blue};">${thisWeekDeals.length}<span style="font-size: 12px; color: ${C.gray500};">/${weeklyTargetDeals}</span></div>
+          <div style="font-size: 10px; color: ${C.gray600}; margin-top: 4px;">${weeklyProgress >= 100 ? '✅ 달성' : `${Math.max(weeklyTargetDeals - thisWeekDeals.length, 0)}건 필요`}</div>
         </div>
-
-        <!-- 성공률 -->
-        <div style="background: ${currentSuccessRate >= T.successRate ? `linear-gradient(135deg, ${C.green}, #00a060)` : C.white}; border-radius: 16px; padding: 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.04); ${currentSuccessRate >= T.successRate ? 'color: white;' : ''}">
-          <div style="display: flex; justify-content: space-between; align-items: start; margin-bottom: 12px;">
-            <div style="font-size: 13px; ${currentSuccessRate >= T.successRate ? 'opacity: 0.9;' : `color: ${C.gray500};`}">성공률</div>
-            <div style="font-size: 12px; font-weight: 600; ${currentSuccessRate >= T.successRate ? '' : `color: ${currentSuccessRate >= T.successRate ? C.green : C.red};`}">${currentSuccessRate >= T.successRate ? '목표 달성!' : `목표 ${T.successRate}%`}</div>
-          </div>
-          <div style="font-size: 32px; font-weight: 800; margin-bottom: 4px;">${currentSuccessRate}%</div>
-          <div style="font-size: 12px; ${currentSuccessRate >= T.successRate ? 'opacity: 0.8;' : `color: ${C.gray400};`}">종료 ${completedDeals.length}건 중 ${successfulDeals.length}건 성공</div>
+        <!-- 이번 달 -->
+        <div style="background: ${monthlyProgress >= 100 ? C.greenLight : C.gray50}; border-radius: 12px; padding: 14px;">
+          <div style="font-size: 11px; color: ${C.gray600}; margin-bottom: 6px;">📆 이번 달</div>
+          <div style="font-size: 20px; font-weight: 700; color: ${monthlyProgress >= 100 ? C.green : C.black};">${monthDeals.length}<span style="font-size: 12px; color: ${C.gray500};">/${monthlyTargetDeals}</span></div>
+          <div style="font-size: 10px; color: ${C.gray600}; margin-top: 4px;">${monthlyProgress >= 100 ? '✅ 달성' : `${Math.max(monthlyTargetDeals - monthDeals.length, 0)}건 필요`}</div>
         </div>
-      </div>
-
-      <!-- ⏰ 주간/월간 목표 대비 현황 -->
-      <div style="background: ${C.white}; border-radius: 16px; padding: 24px; margin-bottom: 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
-        <div style="font-size: 16px; font-weight: 700; color: ${C.black}; margin-bottom: 16px;">⏰ 주간/월간 목표 대비 현황</div>
-
-        <!-- 이번 주/이번 달 진행 현황 -->
-        <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; margin-bottom: 16px;">
-          <!-- 이번 주 -->
-          <div style="background: ${weeklyProgress >= 100 ? C.greenLight : C.blueLight}; border-radius: 14px; padding: 20px;">
-            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;">
-              <div style="font-size: 14px; font-weight: 600; color: ${C.gray700};">📅 이번 주</div>
-              <div style="font-size: 12px; font-weight: 600; color: ${weeklyProgress >= 100 ? C.green : C.blue};">${weeklyProgress}%</div>
-            </div>
-            <div style="display: flex; align-items: baseline; gap: 8px;">
-              <div style="font-size: 36px; font-weight: 800; color: ${weeklyProgress >= 100 ? C.green : C.blue};">${thisWeekDeals.length}</div>
-              <div style="font-size: 16px; color: ${C.gray500};">/ ${weeklyTargetDeals}건</div>
-            </div>
-            <div style="background: rgba(255,255,255,0.6); height: 8px; border-radius: 4px; margin-top: 12px; overflow: hidden;">
-              <div style="background: ${weeklyProgress >= 100 ? C.green : C.blue}; height: 100%; width: ${weeklyProgress}%; border-radius: 4px; transition: width 0.3s;"></div>
-            </div>
-            <div style="font-size: 11px; color: ${C.gray600}; margin-top: 8px;">
-              ${weeklyProgress >= 100 ? '✅ 주간 목표 달성!' : `⚡ ${Math.max(weeklyTargetDeals - thisWeekDeals.length, 0)}건 더 필요`}
-            </div>
-          </div>
-
-          <!-- 이번 달 -->
-          <div style="background: ${monthlyProgress >= 100 ? C.greenLight : C.gray50}; border-radius: 14px; padding: 20px;">
-            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;">
-              <div style="font-size: 14px; font-weight: 600; color: ${C.gray700};">📆 이번 달</div>
-              <div style="font-size: 12px; font-weight: 600; color: ${monthlyProgress >= 100 ? C.green : C.black};">${monthlyProgress}%</div>
-            </div>
-            <div style="display: flex; align-items: baseline; gap: 8px;">
-              <div style="font-size: 36px; font-weight: 800; color: ${monthlyProgress >= 100 ? C.green : C.black};">${monthDeals.length}</div>
-              <div style="font-size: 16px; color: ${C.gray500};">/ ${monthlyTargetDeals}건</div>
-            </div>
-            <div style="background: ${C.gray200}; height: 8px; border-radius: 4px; margin-top: 12px; overflow: hidden;">
-              <div style="background: ${monthlyProgress >= 100 ? C.green : C.primary}; height: 100%; width: ${monthlyProgress}%; border-radius: 4px; transition: width 0.3s;"></div>
-            </div>
-            <div style="font-size: 11px; color: ${C.gray600}; margin-top: 8px;">
-              ${monthlyProgress >= 100 ? '✅ 월간 목표 달성!' : `⚡ ${Math.max(monthlyTargetDeals - monthDeals.length, 0)}건 더 필요 (성공 ${monthSuccessfulDeals.length}건)`}
-            </div>
-          </div>
+        <!-- 남은 목표 -->
+        <div style="background: ${C.white}; border-radius: 12px; padding: 14px; box-shadow: 0 1px 4px rgba(0,0,0,0.04);">
+          <div style="font-size: 11px; color: ${C.gray500}; margin-bottom: 6px;">남은 공구</div>
+          <div style="font-size: 20px; font-weight: 700; color: ${C.black};">${remainingTotalDeals}건</div>
+          <div style="font-size: 10px; color: ${C.gray500}; margin-top: 4px;">주 ${weeklyNeededDeals} / 월 ${monthlyNeededDeals}</div>
         </div>
-
-        <!-- 남은 기간 필요 목표 -->
-        <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px;">
-          <div style="text-align: center; padding: 16px; background: ${C.blueLight}; border-radius: 12px;">
-            <div style="font-size: 11px; color: ${C.gray600}; margin-bottom: 4px;">주간 페이스</div>
-            <div style="font-size: 24px; font-weight: 800; color: ${C.blue};">${weeklyNeededDeals}</div>
-            <div style="font-size: 10px; color: ${C.gray500}; margin-top: 2px;">건/주</div>
-          </div>
-          <div style="text-align: center; padding: 16px; background: ${C.gray50}; border-radius: 12px;">
-            <div style="font-size: 11px; color: ${C.gray600}; margin-bottom: 4px;">월간 페이스</div>
-            <div style="font-size: 24px; font-weight: 800; color: ${C.black};">${monthlyNeededDeals}</div>
-            <div style="font-size: 10px; color: ${C.gray500}; margin-top: 2px;">건/월</div>
-          </div>
-          <div style="text-align: center; padding: 16px; background: ${C.gray50}; border-radius: 12px;">
-            <div style="font-size: 11px; color: ${C.gray600}; margin-bottom: 4px;">남은 공구</div>
-            <div style="font-size: 24px; font-weight: 800; color: ${C.black};">${remainingTotalDeals}</div>
-            <div style="font-size: 10px; color: ${C.gray500}; margin-top: 2px;">건</div>
-          </div>
-          <div style="text-align: center; padding: 16px; background: ${C.greenLight}; border-radius: 12px;">
-            <div style="font-size: 11px; color: ${C.gray600}; margin-bottom: 4px;">남은 성공</div>
-            <div style="font-size: 24px; font-weight: 800; color: ${C.green};">${remainingSuccessDeals}</div>
-            <div style="font-size: 10px; color: ${C.gray500}; margin-top: 2px;">건</div>
-          </div>
-        </div>
-
-        <div style="margin-top: 16px; padding: 14px; background: ${C.yellowLight}; border-radius: 10px;">
-          <div style="font-size: 13px; color: ${C.gray700};">
-            💡 <strong>공구설계 계산기 기준:</strong>
-            주 ${T.weeklyRequiredDeals}건 공구 → 예상 성공 ${Math.round(T.weeklyRequiredDeals * T.successRate / 100)}건 →
-            예상 순익 <strong style="color: ${C.green};">${formatNumber(Math.round(T.weeklyRequiredDeals * T.successRate / 100 * T.avgDealRevenue * 0.22))}원</strong>/주
-          </div>
-        </div>
-      </div>
-
-      <!-- 📋 이번 달 현황 -->
-      <div style="display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px; margin-bottom: 20px;">
-        <div style="background: ${C.white}; border-radius: 12px; padding: 16px; text-align: center; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
-          <div style="font-size: 22px; font-weight: 700; color: ${C.black};">${monthDeals.length}</div>
-          <div style="font-size: 11px; color: ${C.gray500}; margin-top: 4px;">이번달 공구</div>
-          <div style="font-size: 10px; color: ${monthDeals.length >= T.monthlyRequiredDeals ? C.green : C.red}; margin-top: 2px;">목표 ${T.monthlyRequiredDeals}건</div>
-        </div>
-        <div style="background: ${C.white}; border-radius: 12px; padding: 16px; text-align: center; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
-          <div style="font-size: 22px; font-weight: 700; color: ${C.green};">${monthSuccessfulDeals.length}</div>
-          <div style="font-size: 11px; color: ${C.gray500}; margin-top: 4px;">이번달 성공</div>
-        </div>
-        <div style="background: ${C.white}; border-radius: 12px; padding: 16px; text-align: center; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
-          <div style="font-size: 18px; font-weight: 700; color: ${C.blue};">${formatNumber(monthSalesAmount)}원</div>
-          <div style="font-size: 11px; color: ${C.gray500}; margin-top: 4px;">이번달 매출</div>
-        </div>
-        <div style="background: ${C.white}; border-radius: 12px; padding: 16px; text-align: center; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
-          <div style="font-size: 18px; font-weight: 700; color: ${C.green};">${formatNumber(monthProfitAmount)}원</div>
-          <div style="font-size: 11px; color: ${C.gray500}; margin-top: 4px;">이번달 순익</div>
-          <div style="font-size: 10px; color: ${monthProfitAmount >= T.monthlyProfit ? C.green : C.red}; margin-top: 2px;">목표 ${formatNumber(T.monthlyProfit)}원</div>
-        </div>
-        <div style="background: ${C.white}; border-radius: 12px; padding: 16px; text-align: center; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
-          <div style="font-size: 22px; font-weight: 700; color: ${commission30Ratio >= T.commission30Ratio ? C.green : C.yellow};">${commission30Ratio}%</div>
-          <div style="font-size: 11px; color: ${C.gray500}; margin-top: 4px;">30% 수수료 비중</div>
-          <div style="font-size: 10px; color: ${commission30Ratio >= T.commission30Ratio ? C.green : C.yellow}; margin-top: 2px;">목표 ${T.commission30Ratio}%</div>
+        <!-- 30% 수수료 -->
+        <div style="background: ${commission30Ratio >= T.commission30Ratio ? C.greenLight : C.white}; border-radius: 12px; padding: 14px; box-shadow: 0 1px 4px rgba(0,0,0,0.04);">
+          <div style="font-size: 11px; color: ${C.gray500}; margin-bottom: 6px;">30% 수수료</div>
+          <div style="font-size: 20px; font-weight: 700; color: ${commission30Ratio >= T.commission30Ratio ? C.green : C.yellow};">${commission30Ratio}%</div>
+          <div style="font-size: 10px; color: ${C.gray500}; margin-top: 4px;">목표 ${T.commission30Ratio}%</div>
         </div>
       </div>
 
@@ -22708,162 +22577,6 @@ function renderSalesDashboardContent() {
             </table>
           </div>
         `}
-      </div>
-
-      <!-- 👥 셀러 영업 파이프라인 (리스트업 → 컨택 → 입점) -->
-      <div style="background: ${C.white}; border-radius: 16px; padding: 24px; margin-top: 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
-        <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px;">
-          <div style="font-size: 16px; font-weight: 700; color: ${C.black};">👥 셀러 영업 파이프라인</div>
-          <div style="font-size: 12px; color: ${C.gray400};">이번 달 신규: ${sellerJourney.monthNew}명</div>
-        </div>
-
-        <!-- 파이프라인 퍼널 -->
-        <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 20px;">
-          <!-- 리스트업 (등록) -->
-          <div style="flex: 1; text-align: center;">
-            <div style="background: linear-gradient(135deg, ${C.blue}, #3B82F6); color: white; padding: 20px; border-radius: 12px; margin-bottom: 8px;">
-              <div style="font-size: 32px; font-weight: 800;">${sellerJourney.total}</div>
-              <div style="font-size: 12px; opacity: 0.9; margin-top: 4px;">명</div>
-            </div>
-            <div style="font-size: 13px; font-weight: 600; color: ${C.gray700};">📋 리스트업</div>
-            <div style="font-size: 11px; color: ${C.gray500};">전체 등록</div>
-          </div>
-          <div style="font-size: 24px; color: ${C.gray300}; margin: 0 8px;">→</div>
-
-          <!-- 컨택 -->
-          <div style="flex: 1; text-align: center;">
-            <div style="background: ${C.blueLight}; color: ${C.blue}; padding: 20px; border-radius: 12px; margin-bottom: 8px;">
-              <div style="font-size: 32px; font-weight: 800;">${sellerJourney.contacted}</div>
-              <div style="font-size: 12px; opacity: 0.8; margin-top: 4px;">${sellerJourney.total > 0 ? Math.round(sellerJourney.contacted / sellerJourney.total * 100) : 0}%</div>
-            </div>
-            <div style="font-size: 13px; font-weight: 600; color: ${C.gray700};">📞 첫 컨택</div>
-            <div style="font-size: 11px; color: ${C.gray500};">연락 완료</div>
-          </div>
-          <div style="font-size: 24px; color: ${C.gray300}; margin: 0 8px;">→</div>
-
-          <!-- 온보딩 -->
-          <div style="flex: 1; text-align: center;">
-            <div style="background: ${C.yellowLight}; color: ${C.yellow}; padding: 20px; border-radius: 12px; margin-bottom: 8px;">
-              <div style="font-size: 32px; font-weight: 800;">${sellerJourney.onboarded}</div>
-              <div style="font-size: 12px; opacity: 0.8; margin-top: 4px;">${sellerJourney.contacted > 0 ? Math.round(sellerJourney.onboarded / sellerJourney.contacted * 100) : 0}%</div>
-            </div>
-            <div style="font-size: 13px; font-weight: 600; color: ${C.gray700};">📝 온보딩</div>
-            <div style="font-size: 11px; color: ${C.gray500};">설명 완료</div>
-          </div>
-          <div style="font-size: 24px; color: ${C.gray300}; margin: 0 8px;">→</div>
-
-          <!-- 서류 완료 -->
-          <div style="flex: 1; text-align: center;">
-            <div style="background: ${C.gray50}; color: ${C.gray700}; padding: 20px; border-radius: 12px; margin-bottom: 8px;">
-              <div style="font-size: 32px; font-weight: 800;">${sellerJourney.documented}</div>
-              <div style="font-size: 12px; opacity: 0.8; margin-top: 4px;">${sellerJourney.onboarded > 0 ? Math.round(sellerJourney.documented / sellerJourney.onboarded * 100) : 0}%</div>
-            </div>
-            <div style="font-size: 13px; font-weight: 600; color: ${C.gray700};">📄 서류 제출</div>
-            <div style="font-size: 11px; color: ${C.gray500};">입점 준비</div>
-          </div>
-          <div style="font-size: 24px; color: ${C.gray300}; margin: 0 8px;">→</div>
-
-          <!-- 첫 공구 -->
-          <div style="flex: 1; text-align: center;">
-            <div style="background: linear-gradient(135deg, ${C.green}, #059669); color: white; padding: 20px; border-radius: 12px; margin-bottom: 8px;">
-              <div style="font-size: 32px; font-weight: 800;">${sellerJourney.firstDeal}</div>
-              <div style="font-size: 12px; opacity: 0.9; margin-top: 4px;">${sellerJourney.documented > 0 ? Math.round(sellerJourney.firstDeal / sellerJourney.documented * 100) : 0}%</div>
-            </div>
-            <div style="font-size: 13px; font-weight: 600; color: ${C.gray700};">🎉 입점 완료</div>
-            <div style="font-size: 11px; color: ${C.gray500};">첫 공구 진행</div>
-          </div>
-        </div>
-
-        <!-- 전환율 요약 -->
-        <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; padding: 16px; background: ${C.gray50}; border-radius: 10px;">
-          <div style="text-align: center;">
-            <div style="font-size: 18px; font-weight: 700; color: ${C.blue};">${sellerJourney.total > 0 ? Math.round(sellerJourney.contacted / sellerJourney.total * 100) : 0}%</div>
-            <div style="font-size: 11px; color: ${C.gray500};">리스트업→컨택</div>
-          </div>
-          <div style="text-align: center;">
-            <div style="font-size: 18px; font-weight: 700; color: ${C.yellow};">${sellerJourney.contacted > 0 ? Math.round(sellerJourney.onboarded / sellerJourney.contacted * 100) : 0}%</div>
-            <div style="font-size: 11px; color: ${C.gray500};">컨택→온보딩</div>
-          </div>
-          <div style="text-align: center;">
-            <div style="font-size: 18px; font-weight: 700; color: ${C.gray700};">${sellerJourney.onboarded > 0 ? Math.round(sellerJourney.documented / sellerJourney.onboarded * 100) : 0}%</div>
-            <div style="font-size: 11px; color: ${C.gray500};">온보딩→서류</div>
-          </div>
-          <div style="text-align: center;">
-            <div style="font-size: 18px; font-weight: 700; color: ${C.green};">${sellerJourney.total > 0 ? Math.round(sellerJourney.firstDeal / sellerJourney.total * 100) : 0}%</div>
-            <div style="font-size: 11px; color: ${C.gray500};">전체 입점률</div>
-          </div>
-        </div>
-      </div>
-
-      <!-- 🏭 공급사/셀러 통합 현황 -->
-      <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; margin-top: 20px;">
-        <!-- 공급사 현황 -->
-        <div style="background: ${C.white}; border-radius: 16px; padding: 24px; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
-          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px;">
-            <div style="font-size: 15px; font-weight: 700; color: ${C.black};">🏭 공급사 현황</div>
-            <a href="#" onclick="event.preventDefault(); navigateTo('suppliers');" style="font-size: 12px; color: ${C.primary}; text-decoration: none;">전체보기 →</a>
-          </div>
-          <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px;">
-            <div style="background: ${C.gray50}; padding: 16px; border-radius: 10px; text-align: center;">
-              <div style="font-size: 28px; font-weight: 800; color: ${C.black};">${allSuppliers.length}</div>
-              <div style="font-size: 11px; color: ${C.gray500}; margin-top: 4px;">전체</div>
-            </div>
-            <div style="background: ${C.greenLight}; padding: 16px; border-radius: 10px; text-align: center;">
-              <div style="font-size: 28px; font-weight: 800; color: ${C.green};">${contractedSuppliers.length}</div>
-              <div style="font-size: 11px; color: ${C.gray500}; margin-top: 4px;">계약완료</div>
-            </div>
-            <div style="background: ${C.blueLight}; padding: 16px; border-radius: 10px; text-align: center;">
-              <div style="font-size: 28px; font-weight: 800; color: ${C.blue};">${thisMonthSuppliers.length}</div>
-              <div style="font-size: 11px; color: ${C.gray500}; margin-top: 4px;">이번달 신규</div>
-            </div>
-            <div style="background: ${C.primary}15; padding: 16px; border-radius: 10px; text-align: center;">
-              <div style="font-size: 28px; font-weight: 800; color: ${C.primary};">${suppliers30Commission.length}</div>
-              <div style="font-size: 11px; color: ${C.gray500}; margin-top: 4px;">30%↑ 수수료</div>
-            </div>
-          </div>
-          <div style="margin-top: 12px; font-size: 12px; color: ${C.gray500};">
-            월 목표: ${T.monthlyNewSuppliers}개 신규 · 현재 ${thisMonthSuppliers.length}개 (${Math.round(thisMonthSuppliers.length / T.monthlyNewSuppliers * 100)}%)
-          </div>
-        </div>
-
-        <!-- 셀러 현황 -->
-        <div style="background: ${C.white}; border-radius: 16px; padding: 24px; box-shadow: 0 2px 8px rgba(0,0,0,0.04);">
-          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px;">
-            <div style="font-size: 15px; font-weight: 700; color: ${C.black};">👤 셀러 현황</div>
-            <a href="#" onclick="event.preventDefault(); navigateTo('sellers');" style="font-size: 12px; color: ${C.primary}; text-decoration: none;">전체보기 →</a>
-          </div>
-          <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px;">
-            <div style="background: ${C.gray50}; padding: 16px; border-radius: 10px; text-align: center;">
-              <div style="font-size: 28px; font-weight: 800; color: ${C.black};">${allSellers.length}</div>
-              <div style="font-size: 11px; color: ${C.gray500}; margin-top: 4px;">전체</div>
-            </div>
-            <div style="background: ${C.greenLight}; padding: 16px; border-radius: 10px; text-align: center;">
-              <div style="font-size: 28px; font-weight: 800; color: ${C.green};">${sellerJourney.firstDeal}</div>
-              <div style="font-size: 11px; color: ${C.gray500}; margin-top: 4px;">입점완료</div>
-            </div>
-            <div style="background: ${C.blueLight}; padding: 16px; border-radius: 10px; text-align: center;">
-              <div style="font-size: 28px; font-weight: 800; color: ${C.blue};">${sellerJourney.monthNew}</div>
-              <div style="font-size: 11px; color: ${C.gray500}; margin-top: 4px;">이번달 신규</div>
-            </div>
-            <div style="background: ${C.yellowLight}; padding: 16px; border-radius: 10px; text-align: center;">
-              <div style="font-size: 28px; font-weight: 800; color: ${C.yellow};">${sellerJourney.contacted - sellerJourney.firstDeal}</div>
-              <div style="font-size: 11px; color: ${C.gray500}; margin-top: 4px;">진행중</div>
-            </div>
-          </div>
-          <div style="margin-top: 12px; font-size: 12px; color: ${C.gray500};">
-            월 목표: ${T.monthlyNewSellers}명 신규 · 현재 ${sellerJourney.monthNew}명 (${Math.round(sellerJourney.monthNew / T.monthlyNewSellers * 100)}%)
-          </div>
-        </div>
-      </div>
-
-      <!-- 📌 전략 요약 -->
-      <div style="margin-top: 20px; padding: 16px 20px; background: ${C.gray50}; border-radius: 12px; border: 1px solid ${C.gray200};">
-        <div style="font-size: 13px; color: ${C.gray600}; line-height: 1.7;">
-          📌 <strong>전략기획 연동:</strong>
-          연 매출 ${(T.annualRevenue / 100000000)}억 달성 = 성공 공구 ${T.targetSuccessDeals}건 필요 →
-          성공률 ${T.successRate}% 반영 시 <strong>전체 ${T.requiredTotalDeals}건 공구</strong> 필요
-          (월 ${T.monthlyRequiredDeals}건, 주 ${T.weeklyRequiredDeals}건)
-        </div>
       </div>
 
     </div>


### PR DESCRIPTION
- 셀러 영업 파이프라인 퍼널 시각화 제거 (팀원별 파이프라인 성과 테이블로 대체)
- 공급사/셀러 통합 현황 섹션 제거 (이미 KPI에 표시됨)
- 전략 요약 footer 제거 (헤더에 통합됨)
- 잔여 코드 정리