### PR TITLE
템플릿 리터럴 내 script 태그 제거 - 파싱 오류 수정

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -9753,11 +9753,11 @@ function openSellerListModal(item = null, bulk = false) {
               <span style="font-weight: 500; color: ${s.proposed ? '#16a34a' : 'inherit'};">① 제안완료</span>
             </label>
             <label class="checkbox-wrapper" style="padding: 10px 16px; background: white; border-radius: 8px; border: 2px solid ${s.onboarding ? '#3b82f6' : '#e5e7eb'};">
-              <input type="checkbox" id="sl-onboarding" ${s.onboarding ? 'checked' : ''}>
+              <input type="checkbox" id="sl-onboarding" ${s.onboarding ? 'checked' : ''} onchange="document.getElementById('sl-source-section').style.display = (this.checked || document.getElementById('sl-contracted').checked) ? 'block' : 'none'">
               <span style="font-weight: 500; color: ${s.onboarding ? '#1d4ed8' : 'inherit'};">② 온보딩</span>
             </label>
             <label class="checkbox-wrapper" style="padding: 10px 16px; background: ${s.contracted ? 'linear-gradient(135deg, #8b5cf6, #7c3aed)' : 'white'}; border-radius: 8px; border: 2px solid ${s.contracted ? '#8b5cf6' : '#e5e7eb'};">
-              <input type="checkbox" id="sl-contracted" ${s.contracted ? 'checked' : ''}>
+              <input type="checkbox" id="sl-contracted" ${s.contracted ? 'checked' : ''} onchange="document.getElementById('sl-source-section').style.display = (this.checked || document.getElementById('sl-onboarding').checked) ? 'block' : 'none'">
               <span style="font-weight: 500; color: ${s.contracted ? 'white' : 'inherit'};">③ 계약완료</span>
             </label>
           </div>
@@ -9795,16 +9795,6 @@ function openSellerListModal(item = null, bulk = false) {
           </div>
         </div>
 
-        <script>
-          // 온보딩 체크 시 유입경로 섹션 표시
-          document.getElementById('sl-onboarding')?.addEventListener('change', function() {
-            document.getElementById('sl-source-section').style.display = this.checked || document.getElementById('sl-contracted').checked ? 'block' : 'none';
-          });
-          document.getElementById('sl-contracted')?.addEventListener('change', function() {
-            document.getElementById('sl-source-section').style.display = this.checked || document.getElementById('sl-onboarding').checked ? 'block' : 'none';
-          });
-        </script>
-        
         <div class="form-group">
           <label class="form-label">비고</label>
           <textarea class="form-textarea" id="sl-notes" rows="3" placeholder="추가 메모 (협상 진행상황, 특이사항 등)">${s.notes || ''}</textarea>
@@ -11984,7 +11974,7 @@ function openProductListModal(itemId = null) {
               <span style="font-weight: 500; color: ${p.proposed ? '#16a34a' : 'inherit'};">① 제안완료</span>
             </label>
             <label class="checkbox-wrapper" style="padding: 10px 16px; background: white; border-radius: 8px; border: 2px solid ${p.onboarding || p.contacted ? '#3b82f6' : '#e5e7eb'};">
-              <input type="checkbox" id="pl-onboarding" ${p.onboarding || p.contacted ? 'checked' : ''}>
+              <input type="checkbox" id="pl-onboarding" ${p.onboarding || p.contacted ? 'checked' : ''} onchange="document.getElementById('pl-source-section').style.display = this.checked ? 'block' : 'none'">
               <span style="font-weight: 500; color: ${p.onboarding || p.contacted ? '#1d4ed8' : 'inherit'};">② 온보딩</span>
             </label>
             <label class="checkbox-wrapper" style="padding: 10px 16px; background: ${p.contracted ? 'linear-gradient(135deg, #8b5cf6, #7c3aed)' : 'white'}; border-radius: 8px; border: 2px solid ${p.contracted ? '#8b5cf6' : '#e5e7eb'};">
@@ -12022,13 +12012,8 @@ function openProductListModal(itemId = null) {
             </select>
           </div>
 
-          <script>
-            document.getElementById('pl-onboarding').addEventListener('change', function() {
-              document.getElementById('pl-source-section').style.display = this.checked ? 'block' : 'none';
-            });
-          </script>
         </div>
-        
+
         <div class="form-group">
           <label class="form-label">비고</label>
           <textarea class="form-textarea" id="pl-notes" rows="3" placeholder="메모 (공구 제안 시 참고사항 등)">${p.notes || ''}</textarea>


### PR DESCRIPTION
- 템플릿 리터럴 내 </script>가 외부 스크립트를 닫아버리는 문제 해결
- inline onchange 속성으로 대체