### PR TITLE
파이프라인 구조 개편: 컨택→온보딩 통합 및 유입경로 추적

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -9744,22 +9744,49 @@ function openSellerListModal(item = null, bulk = false) {
           </div>
         </div>
         
-        <!-- 진행 상태 (제안 → 컨택 → 계약 순서) -->
+        <!-- 진행 상태 (제안 → 온보딩 → 계약) -->
         <div style="margin-bottom: 20px; padding: 16px; background: var(--gray-50); border-radius: 12px;">
-          <h4 style="font-size: 14px; font-weight: 600; margin-bottom: 12px; color: var(--gray-700);">진행 상태 <span style="font-weight: 400; font-size: 12px; color: var(--gray-500);">(제안 → 컨택 → 계약)</span></h4>
+          <h4 style="font-size: 14px; font-weight: 600; margin-bottom: 12px; color: var(--gray-700);">진행 상태 <span style="font-weight: 400; font-size: 12px; color: var(--gray-500);">(제안 → 온보딩 → 계약)</span></h4>
           <div style="display: flex; gap: 16px; flex-wrap: wrap;">
             <label class="checkbox-wrapper" style="padding: 10px 16px; background: white; border-radius: 8px; border: 2px solid ${s.proposed ? '#22c55e' : '#e5e7eb'};">
               <input type="checkbox" id="sl-proposed" ${s.proposed ? 'checked' : ''}>
               <span style="font-weight: 500; color: ${s.proposed ? '#16a34a' : 'inherit'};">① 제안완료</span>
             </label>
-            <label class="checkbox-wrapper" style="padding: 10px 16px; background: white; border-radius: 8px; border: 2px solid ${s.contacted ? '#3b82f6' : '#e5e7eb'};">
-              <input type="checkbox" id="sl-contacted" ${s.contacted ? 'checked' : ''}>
-              <span style="font-weight: 500; color: ${s.contacted ? '#1d4ed8' : 'inherit'};">② 컨택완료</span>
+            <label class="checkbox-wrapper" style="padding: 10px 16px; background: white; border-radius: 8px; border: 2px solid ${s.onboarding || s.contacted ? '#3b82f6' : '#e5e7eb'};">
+              <input type="checkbox" id="sl-onboarding" ${s.onboarding || s.contacted ? 'checked' : ''} onchange="document.getElementById('sl-source-section').style.display=this.checked?'block':'none'">
+              <span style="font-weight: 500; color: ${s.onboarding || s.contacted ? '#1d4ed8' : 'inherit'};">② 온보딩</span>
             </label>
             <label class="checkbox-wrapper" style="padding: 10px 16px; background: ${s.contracted ? 'linear-gradient(135deg, #8b5cf6, #7c3aed)' : 'white'}; border-radius: 8px; border: 2px solid ${s.contracted ? '#8b5cf6' : '#e5e7eb'};">
               <input type="checkbox" id="sl-contracted" ${s.contracted ? 'checked' : ''}>
-              <span style="font-weight: 500; color: ${s.contracted ? 'white' : 'inherit'};">③ 입점계약</span>
+              <span style="font-weight: 500; color: ${s.contracted ? 'white' : 'inherit'};">③ 계약완료</span>
             </label>
+          </div>
+          <div id="sl-source-section" style="margin-top: 16px; padding-top: 16px; border-top: 1px dashed #e5e7eb; display: ${s.onboarding || s.contacted ? 'block' : 'none'};">
+            <h4 style="font-size: 13px; font-weight: 600; margin-bottom: 10px; color: var(--gray-600);">📊 유입경로</h4>
+            <div style="display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 12px;">
+              <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;">
+                <input type="radio" name="sl-sourceType" value="outbound" ${s.sourceType === 'outbound' ? 'checked' : ''}>
+                <span style="font-size: 13px;">📤 아웃바운드 (직접제안)</span>
+              </label>
+              <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;">
+                <input type="radio" name="sl-sourceType" value="inbound" ${s.sourceType === 'inbound' ? 'checked' : ''}>
+                <span style="font-size: 13px;">📥 인바운드 (외부유입)</span>
+              </label>
+            </div>
+            <select id="sl-sourceDetail" class="form-select" style="max-width: 200px; font-size: 13px;">
+              <option value="">상세 선택</option>
+              <optgroup label="아웃바운드">
+                <option value="직접제안" ${s.sourceDetail === '직접제안' ? 'selected' : ''}>직접제안</option>
+                <option value="콜드메일" ${s.sourceDetail === '콜드메일' ? 'selected' : ''}>콜드메일</option>
+                <option value="DM발송" ${s.sourceDetail === 'DM발송' ? 'selected' : ''}>DM발송</option>
+              </optgroup>
+              <optgroup label="인바운드">
+                <option value="지인추천" ${s.sourceDetail === '지인추천' ? 'selected' : ''}>지인추천</option>
+                <option value="광고유입" ${s.sourceDetail === '광고유입' ? 'selected' : ''}>광고유입</option>
+                <option value="SNS유입" ${s.sourceDetail === 'SNS유입' ? 'selected' : ''}>SNS유입</option>
+                <option value="문의접수" ${s.sourceDetail === '문의접수' ? 'selected' : ''}>문의접수</option>
+              </optgroup>
+            </select>
           </div>
         </div>
         
@@ -9854,6 +9881,11 @@ function submitSellerListForm(e, id) {
   const productInputs = document.querySelectorAll('input[name="sl-proposedProducts"]');
   const proposedProducts = Array.from(productInputs).map(input => input.value);
   
+  // 유입경로 수집
+  const sourceTypeRadio = document.querySelector('input[name="sl-sourceType"]:checked');
+  const sourceType = sourceTypeRadio ? sourceTypeRadio.value : '';
+  const sourceDetail = document.getElementById('sl-sourceDetail')?.value || '';
+
   const data = {
     category: document.getElementById('sl-category').value,
     accountName: document.getElementById('sl-accountName').value,
@@ -9862,9 +9894,11 @@ function submitSellerListForm(e, id) {
     accountLink: document.getElementById('sl-accountLink').value,
     marginRate: Number(document.getElementById('sl-marginRate').value) || 0,
     eventSupport: eventSupport,
-    contacted: document.getElementById('sl-contacted').checked,
     proposed: document.getElementById('sl-proposed').checked,
+    onboarding: document.getElementById('sl-onboarding').checked,
     contracted: document.getElementById('sl-contracted').checked,
+    sourceType: sourceType,
+    sourceDetail: sourceDetail,
     proposedProducts: proposedProducts,
     notes: document.getElementById('sl-notes').value,
     updatedAt: new Date().toISOString(),
@@ -10057,7 +10091,7 @@ function renderSellerList() {
   const totalCount = allSellers.length;
   const notProposedCount = allSellers.filter(s => !s.proposed).length;
   const proposedCount = allSellers.filter(s => s.proposed).length;
-  const contactedCount = allSellers.filter(s => s.contacted).length;
+  const onboardingCount = allSellers.filter(s => s.onboarding || s.contacted).length;
   const contractedCount = allSellers.filter(s => s.contracted).length;
   
   // 카테고리 목록 추출
@@ -10110,15 +10144,15 @@ function renderSellerList() {
       ${searchKeyword ? `<p style="font-size: 13px; color: var(--gray-500); margin-top: 8px;">"${searchKeyword}" 검색 결과: ${filteredSellers.length}건</p>` : ''}
     </div>
     
-    <!-- 상태 필터 (제안 → 컨택 → 계약 순서) -->
+    <!-- 상태 필터 (제안 → 온보딩 → 계약) -->
     <div class="card" style="margin-bottom: 16px;">
       <div class="filter-bar">
         <div class="filter-group">
           <button class="filter-btn ${!window.sellerListStatusFilter ? 'active' : ''}" onclick="filterSellerListByStatus('')">전체</button>
           <button class="filter-btn ${window.sellerListStatusFilter === 'notProposed' ? 'active' : ''}" onclick="filterSellerListByStatus('notProposed')" style="color: #d97706;">미제안</button>
           <button class="filter-btn ${window.sellerListStatusFilter === 'proposed' ? 'active' : ''}" onclick="filterSellerListByStatus('proposed')" style="color: #16a34a;">제안완료</button>
-          <button class="filter-btn ${window.sellerListStatusFilter === 'contacted' ? 'active' : ''}" onclick="filterSellerListByStatus('contacted')" style="color: #1d4ed8;">컨택완료</button>
-          <button class="filter-btn ${window.sellerListStatusFilter === 'contracted' ? 'active' : ''}" onclick="filterSellerListByStatus('contracted')" style="color: #7c3aed;">입점계약</button>
+          <button class="filter-btn ${window.sellerListStatusFilter === 'onboarding' ? 'active' : ''}" onclick="filterSellerListByStatus('onboarding')" style="color: #1d4ed8;">온보딩</button>
+          <button class="filter-btn ${window.sellerListStatusFilter === 'contracted' ? 'active' : ''}" onclick="filterSellerListByStatus('contracted')" style="color: #7c3aed;">계약완료</button>
         </div>
       </div>
     </div>
@@ -10181,17 +10215,17 @@ function renderSellerList() {
               .filter(s => {
                 if (window.slCategoryFilter && s.category !== window.slCategoryFilter) return false;
                 if (window.sellerListStatusFilter === 'notProposed' && s.proposed) return false;
-                if (window.sellerListStatusFilter === 'proposed' && (!s.proposed || s.contacted)) return false;
-                if (window.sellerListStatusFilter === 'contacted' && (!s.contacted || s.contracted)) return false;
+                if (window.sellerListStatusFilter === 'proposed' && (!s.proposed || s.onboarding || s.contacted)) return false;
+                if (window.sellerListStatusFilter === 'onboarding' && (!(s.onboarding || s.contacted) || s.contracted)) return false;
                 if (window.sellerListStatusFilter === 'contracted' && !s.contracted) return false;
                 return true;
               })
               .map(s => {
-                // 행 배경색 결정 (계약 > 컨택 > 제안 > 미제안)
+                // 행 배경색 결정 (계약 > 온보딩 > 제안 > 미제안)
                 let rowBg = '';
                 if (s.contracted) {
                   rowBg = 'background: #f5f3ff;'; // 연한 보라
-                } else if (s.contacted) {
+                } else if (s.onboarding || s.contacted) {
                   rowBg = 'background: #eff6ff;'; // 연한 파랑
                 } else if (s.proposed) {
                   rowBg = 'background: #f0fdf4;'; // 연한 초록
@@ -11323,10 +11357,10 @@ function renderProductList() {
                           (p.category || '').toLowerCase().includes(searchKeyword.toLowerCase()))
     : allItems;
   
-  // 통계 (순서: 제안 → 컨택 → 계약)
+  /// 통계 (순서: 제안 → 온보딩 → 계약)
   const totalCount = allItems.length;
   const proposedCount = allItems.filter(p => p.proposed).length;
-  const contactedCount = allItems.filter(p => p.contacted).length;
+  const onboardingCount = allItems.filter(p => p.onboarding || p.contacted).length;
   const contractedCount = allItems.filter(p => p.contracted).length;
   const notProposedCount = allItems.filter(p => !p.proposed).length;
   
@@ -11380,14 +11414,14 @@ function renderProductList() {
       ${searchKeyword ? `<p style="font-size: 13px; color: var(--gray-500); margin-top: 8px;">"${searchKeyword}" 검색 결과: ${items.length}건</p>` : ''}
     </div>
     
-    <!-- 상태 필터 (제안 → 컨택 → 계약 순서) -->
+    <!-- 상태 필터 (제안 → 온보딩 → 계약) -->
     <div class="card" style="margin-bottom: 16px;">
       <div class="filter-bar">
         <div class="filter-group">
           <button class="filter-btn ${!window.productListStatusFilter ? 'active' : ''}" onclick="filterProductListByStatus('')">전체</button>
           <button class="filter-btn ${window.productListStatusFilter === 'notProposed' ? 'active' : ''}" onclick="filterProductListByStatus('notProposed')" style="color: #d97706;">미제안</button>
           <button class="filter-btn ${window.productListStatusFilter === 'proposed' ? 'active' : ''}" onclick="filterProductListByStatus('proposed')" style="color: #16a34a;">제안완료</button>
-          <button class="filter-btn ${window.productListStatusFilter === 'contacted' ? 'active' : ''}" onclick="filterProductListByStatus('contacted')" style="color: #1d4ed8;">컨택완료</button>
+          <button class="filter-btn ${window.productListStatusFilter === 'onboarding' ? 'active' : ''}" onclick="filterProductListByStatus('onboarding')" style="color: #1d4ed8;">온보딩</button>
           <button class="filter-btn ${window.productListStatusFilter === 'contracted' ? 'active' : ''}" onclick="filterProductListByStatus('contracted')" style="color: #7c3aed;">계약완료</button>
         </div>
       </div>
@@ -11441,17 +11475,17 @@ function renderProductList() {
                 .filter(p => {
                   if (window.productListCategoryFilter && p.category !== window.productListCategoryFilter) return false;
                   if (window.productListStatusFilter === 'notProposed' && p.proposed) return false;
-                  if (window.productListStatusFilter === 'proposed' && (!p.proposed || p.contacted)) return false;
-                  if (window.productListStatusFilter === 'contacted' && (!p.contacted || p.contracted)) return false;
+                  if (window.productListStatusFilter === 'proposed' && (!p.proposed || p.onboarding || p.contacted)) return false;
+                  if (window.productListStatusFilter === 'onboarding' && (!(p.onboarding || p.contacted) || p.contracted)) return false;
                   if (window.productListStatusFilter === 'contracted' && !p.contracted) return false;
                   return true;
                 })
                 .map(p => {
-                  // 행 배경색 결정 (계약 > 컨택 > 제안 > 미제안)
+                  // 행 배경색 결정 (계약 > 온보딩 > 제안 > 미제안)
                   let rowBg = '';
                   if (p.contracted) {
                     rowBg = 'background: #f5f3ff;'; // 연한 보라
-                  } else if (p.contacted) {
+                  } else if (p.onboarding || p.contacted) {
                     rowBg = 'background: #eff6ff;'; // 연한 파랑
                   } else if (p.proposed) {
                     rowBg = 'background: #f0fdf4;'; // 연한 초록
@@ -11926,22 +11960,49 @@ function openProductListModal(itemId = null) {
           <input type="url" class="form-input" id="pl-link" value="${p.sourceLink || ''}" placeholder="상품 페이지 URL">
         </div>
         
-        <!-- 진행 상태 (제안 → 컨택 → 계약 순서) -->
+        <!-- 진행 상태 (제안 → 온보딩 → 계약) -->
         <div style="margin-bottom: 20px; padding: 16px; background: var(--gray-50); border-radius: 12px;">
-          <h4 style="font-size: 14px; font-weight: 600; margin-bottom: 12px; color: var(--gray-700);">진행 상태 <span style="font-weight: 400; font-size: 12px; color: var(--gray-500);">(제안 → 컨택 → 계약)</span></h4>
+          <h4 style="font-size: 14px; font-weight: 600; margin-bottom: 12px; color: var(--gray-700);">진행 상태 <span style="font-weight: 400; font-size: 12px; color: var(--gray-500);">(제안 → 온보딩 → 계약)</span></h4>
           <div style="display: flex; gap: 16px; flex-wrap: wrap;">
             <label class="checkbox-wrapper" style="padding: 10px 16px; background: white; border-radius: 8px; border: 2px solid ${p.proposed ? '#22c55e' : '#e5e7eb'};">
               <input type="checkbox" id="pl-proposed" ${p.proposed ? 'checked' : ''}>
               <span style="font-weight: 500; color: ${p.proposed ? '#16a34a' : 'inherit'};">① 제안완료</span>
             </label>
-            <label class="checkbox-wrapper" style="padding: 10px 16px; background: white; border-radius: 8px; border: 2px solid ${p.contacted ? '#3b82f6' : '#e5e7eb'};">
-              <input type="checkbox" id="pl-contacted" ${p.contacted ? 'checked' : ''}>
-              <span style="font-weight: 500; color: ${p.contacted ? '#1d4ed8' : 'inherit'};">② 컨택완료</span>
+            <label class="checkbox-wrapper" style="padding: 10px 16px; background: white; border-radius: 8px; border: 2px solid ${p.onboarding || p.contacted ? '#3b82f6' : '#e5e7eb'};">
+              <input type="checkbox" id="pl-onboarding" ${p.onboarding || p.contacted ? 'checked' : ''} onchange="document.getElementById('pl-source-section').style.display=this.checked?'block':'none'">
+              <span style="font-weight: 500; color: ${p.onboarding || p.contacted ? '#1d4ed8' : 'inherit'};">② 온보딩</span>
             </label>
             <label class="checkbox-wrapper" style="padding: 10px 16px; background: ${p.contracted ? 'linear-gradient(135deg, #8b5cf6, #7c3aed)' : 'white'}; border-radius: 8px; border: 2px solid ${p.contracted ? '#8b5cf6' : '#e5e7eb'};">
               <input type="checkbox" id="pl-contracted" ${p.contracted ? 'checked' : ''}>
               <span style="font-weight: 500; color: ${p.contracted ? 'white' : 'inherit'};">③ 계약완료</span>
             </label>
+          </div>
+          <div id="pl-source-section" style="margin-top: 16px; padding-top: 16px; border-top: 1px dashed #e5e7eb; display: ${p.onboarding || p.contacted ? 'block' : 'none'};">
+            <h4 style="font-size: 13px; font-weight: 600; margin-bottom: 10px; color: var(--gray-600);">📊 유입경로</h4>
+            <div style="display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 12px;">
+              <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;">
+                <input type="radio" name="pl-sourceType" value="outbound" ${p.sourceType === 'outbound' ? 'checked' : ''}>
+                <span style="font-size: 13px;">📤 아웃바운드 (직접제안)</span>
+              </label>
+              <label style="display: flex; align-items: center; gap: 6px; cursor: pointer;">
+                <input type="radio" name="pl-sourceType" value="inbound" ${p.sourceType === 'inbound' ? 'checked' : ''}>
+                <span style="font-size: 13px;">📥 인바운드 (외부유입)</span>
+              </label>
+            </div>
+            <select id="pl-sourceDetail" class="form-select" style="max-width: 200px; font-size: 13px;">
+              <option value="">상세 선택</option>
+              <optgroup label="아웃바운드">
+                <option value="직접제안" ${p.sourceDetail === '직접제안' ? 'selected' : ''}>직접제안</option>
+                <option value="콜드메일" ${p.sourceDetail === '콜드메일' ? 'selected' : ''}>콜드메일</option>
+                <option value="DM발송" ${p.sourceDetail === 'DM발송' ? 'selected' : ''}>DM발송</option>
+              </optgroup>
+              <optgroup label="인바운드">
+                <option value="지인추천" ${p.sourceDetail === '지인추천' ? 'selected' : ''}>지인추천</option>
+                <option value="광고유입" ${p.sourceDetail === '광고유입' ? 'selected' : ''}>광고유입</option>
+                <option value="SNS유입" ${p.sourceDetail === 'SNS유입' ? 'selected' : ''}>SNS유입</option>
+                <option value="문의접수" ${p.sourceDetail === '문의접수' ? 'selected' : ''}>문의접수</option>
+              </optgroup>
+            </select>
           </div>
         </div>
         
@@ -11966,7 +12027,12 @@ function openProductListModal(itemId = null) {
 async function saveProductListItem(e, itemId) {
   e.preventDefault();
   if (!canEdit()) { showNoPermission(); return; }
-  
+
+  // 유입경로 수집
+  const sourceTypeRadio = document.querySelector('input[name="pl-sourceType"]:checked');
+  const sourceType = sourceTypeRadio ? sourceTypeRadio.value : '';
+  const sourceDetail = document.getElementById('pl-sourceDetail')?.value || '';
+
   const data = {
     category: document.getElementById('pl-category').value,
     brandName: document.getElementById('pl-brand').value,
@@ -11975,8 +12041,10 @@ async function saveProductListItem(e, itemId) {
     source: document.getElementById('pl-source').value,
     sourceLink: document.getElementById('pl-link').value,
     proposed: document.getElementById('pl-proposed').checked,
-    contacted: document.getElementById('pl-contacted').checked,
+    onboarding: document.getElementById('pl-onboarding').checked,
     contracted: document.getElementById('pl-contracted').checked,
+    sourceType: sourceType,
+    sourceDetail: sourceDetail,
     notes: document.getElementById('pl-notes').value,
     updatedAt: new Date().toISOString(),
     updatedBy: getCurrentUserId()
@@ -22213,25 +22281,30 @@ function renderSalesDashboardContent() {
   const topProductsByQty = Object.values(productSalesMap).sort((a, b) => b.quantity - a.quantity).slice(0, 5);
   const topProductsBySales = Object.values(productSalesMap).sort((a, b) => b.sales - a.sales).slice(0, 5);
 
-  // 팀원별 실적 계산 (파이프라인 포함)
+  // 팀원별 실적 계산 (파이프라인 포함 - sellerList/productList 기반)
+  const allSellerList = state.sellerList || [];
+  const allProductList = state.productList || [];
+
   const memberStats = members.filter(m => m.role !== 'ceo').map(member => {
     const mSuppliers = state.suppliers.filter(s => s.registeredBy === member.id);
     const mSellers = state.sellers.filter(s => s.registeredBy === member.id);
 
-    // 셀러 파이프라인 단계별 카운트
+    // 셀러 파이프라인 (sellerList 기반): 리스트업 → 제안 → 온보딩 → 계약
+    const mSellerList = allSellerList.filter(s => s.createdBy === member.id);
     const sellerPipeline = {
-      total: mSellers.length,
-      contacted: mSellers.filter(s => s.journeyFirstContact).length,
-      onboarded: mSellers.filter(s => s.journeyOnboarding).length,
-      documented: mSellers.filter(s => s.journeyDocuments).length,
-      firstDeal: mSellers.filter(s => s.journeyFirstDeal).length
+      total: mSellerList.length,
+      proposed: mSellerList.filter(s => s.proposed).length,
+      onboarding: mSellerList.filter(s => s.onboarding || s.contacted).length,
+      contracted: mSellerList.filter(s => s.contracted).length
     };
 
-    // 공급사 파이프라인 단계별 카운트
+    // 상품 파이프라인 (productList 기반): 리스트업 → 제안 → 온보딩 → 계약
+    const mProductList = allProductList.filter(s => s.createdBy === member.id);
     const supplierPipeline = {
-      total: mSuppliers.length,
-      contracted: mSuppliers.filter(s => s.contractStatus === 'completed').length,
-      hasProducts: mSuppliers.filter(s => s.hasProductInfo).length
+      total: mProductList.length,
+      proposed: mProductList.filter(s => s.proposed).length,
+      onboarding: mProductList.filter(s => s.onboarding || s.contacted).length,
+      contracted: mProductList.filter(s => s.contracted).length
     };
     const mDeals = allDeals.filter(d => d.registeredBy === member.id);
     const mYearDeals = mDeals.filter(d => (d.startDate || d.createdAt || '').startsWith(thisYearStr));
@@ -22583,18 +22656,18 @@ function renderSalesDashboardContent() {
               <thead>
                 <tr style="background: linear-gradient(135deg, #EEF2FF, #FEF3C7);">
                   <th rowspan="2" style="padding: 10px 8px; text-align: left; font-weight: 600; color: ${C.gray700}; border-bottom: 2px solid ${C.gray200};">팀원</th>
-                  <th colspan="5" style="padding: 8px; text-align: center; font-weight: 700; color: #B45309; border-bottom: 1px solid #FCD34D; background: #FEF3C7;">👤 셀러 파이프라인</th>
-                  <th colspan="3" style="padding: 8px; text-align: center; font-weight: 700; color: #4338CA; border-bottom: 1px solid #C7D2FE; background: #EEF2FF;">🏭 공급사 파이프라인</th>
+                  <th colspan="4" style="padding: 8px; text-align: center; font-weight: 700; color: #B45309; border-bottom: 1px solid #FCD34D; background: #FEF3C7;">👤 셀러 파이프라인</th>
+                  <th colspan="4" style="padding: 8px; text-align: center; font-weight: 700; color: #4338CA; border-bottom: 1px solid #C7D2FE; background: #EEF2FF;">📦 상품 파이프라인</th>
                 </tr>
                 <tr style="background: ${C.gray50};">
                   <th style="padding: 8px 6px; text-align: center; font-weight: 500; color: ${C.gray600}; border-bottom: 2px solid ${C.gray200};">리스트업</th>
-                  <th style="padding: 8px 6px; text-align: center; font-weight: 500; color: ${C.gray600}; border-bottom: 2px solid ${C.gray200};">컨택</th>
+                  <th style="padding: 8px 6px; text-align: center; font-weight: 500; color: ${C.gray600}; border-bottom: 2px solid ${C.gray200};">제안</th>
                   <th style="padding: 8px 6px; text-align: center; font-weight: 500; color: ${C.gray600}; border-bottom: 2px solid ${C.gray200};">온보딩</th>
-                  <th style="padding: 8px 6px; text-align: center; font-weight: 500; color: ${C.gray600}; border-bottom: 2px solid ${C.gray200};">서류</th>
-                  <th style="padding: 8px 6px; text-align: center; font-weight: 500; color: #B45309; border-bottom: 2px solid ${C.gray200};">입점</th>
+                  <th style="padding: 8px 6px; text-align: center; font-weight: 500; color: #B45309; border-bottom: 2px solid ${C.gray200};">계약</th>
                   <th style="padding: 8px 6px; text-align: center; font-weight: 500; color: ${C.gray600}; border-bottom: 2px solid ${C.gray200};">리스트업</th>
-                  <th style="padding: 8px 6px; text-align: center; font-weight: 500; color: ${C.gray600}; border-bottom: 2px solid ${C.gray200};">상품등록</th>
-                  <th style="padding: 8px 6px; text-align: center; font-weight: 500; color: #4338CA; border-bottom: 2px solid ${C.gray200};">계약완료</th>
+                  <th style="padding: 8px 6px; text-align: center; font-weight: 500; color: ${C.gray600}; border-bottom: 2px solid ${C.gray200};">제안</th>
+                  <th style="padding: 8px 6px; text-align: center; font-weight: 500; color: ${C.gray600}; border-bottom: 2px solid ${C.gray200};">온보딩</th>
+                  <th style="padding: 8px 6px; text-align: center; font-weight: 500; color: #4338CA; border-bottom: 2px solid ${C.gray200};">계약</th>
                 </tr>
               </thead>
               <tbody>
@@ -22609,12 +22682,12 @@ function renderSalesDashboardContent() {
                       </div>
                     </td>
                     <td style="padding: 8px 6px; text-align: center; font-weight: 600;">${m.sellerPipeline.total}</td>
-                    <td style="padding: 8px 6px; text-align: center; color: ${m.sellerPipeline.contacted > 0 ? C.blue : C.gray400};">${m.sellerPipeline.contacted}</td>
-                    <td style="padding: 8px 6px; text-align: center; color: ${m.sellerPipeline.onboarded > 0 ? C.yellow : C.gray400};">${m.sellerPipeline.onboarded}</td>
-                    <td style="padding: 8px 6px; text-align: center; color: ${m.sellerPipeline.documented > 0 ? C.gray700 : C.gray400};">${m.sellerPipeline.documented}</td>
-                    <td style="padding: 8px 6px; text-align: center;"><span style="background: ${m.sellerPipeline.firstDeal > 0 ? '#FEF3C7' : C.gray100}; color: ${m.sellerPipeline.firstDeal > 0 ? '#B45309' : C.gray400}; padding: 2px 8px; border-radius: 10px; font-weight: 700;">${m.sellerPipeline.firstDeal}</span></td>
+                    <td style="padding: 8px 6px; text-align: center; color: ${m.sellerPipeline.proposed > 0 ? C.green : C.gray400};">${m.sellerPipeline.proposed}</td>
+                    <td style="padding: 8px 6px; text-align: center; color: ${m.sellerPipeline.onboarding > 0 ? C.blue : C.gray400};">${m.sellerPipeline.onboarding}</td>
+                    <td style="padding: 8px 6px; text-align: center;"><span style="background: ${m.sellerPipeline.contracted > 0 ? '#FEF3C7' : C.gray100}; color: ${m.sellerPipeline.contracted > 0 ? '#B45309' : C.gray400}; padding: 2px 8px; border-radius: 10px; font-weight: 700;">${m.sellerPipeline.contracted}</span></td>
                     <td style="padding: 8px 6px; text-align: center; font-weight: 600;">${m.supplierPipeline.total}</td>
-                    <td style="padding: 8px 6px; text-align: center; color: ${m.supplierPipeline.hasProducts > 0 ? C.gray700 : C.gray400};">${m.supplierPipeline.hasProducts}</td>
+                    <td style="padding: 8px 6px; text-align: center; color: ${m.supplierPipeline.proposed > 0 ? C.green : C.gray400};">${m.supplierPipeline.proposed}</td>
+                    <td style="padding: 8px 6px; text-align: center; color: ${m.supplierPipeline.onboarding > 0 ? C.blue : C.gray400};">${m.supplierPipeline.onboarding}</td>
                     <td style="padding: 8px 6px; text-align: center;"><span style="background: ${m.supplierPipeline.contracted > 0 ? '#EEF2FF' : C.gray100}; color: ${m.supplierPipeline.contracted > 0 ? '#4338CA' : C.gray400}; padding: 2px 8px; border-radius: 10px; font-weight: 700;">${m.supplierPipeline.contracted}</span></td>
                   </tr>
                 `).join('')}
@@ -22623,12 +22696,12 @@ function renderSalesDashboardContent() {
                 <tr style="background: ${C.gray50}; border-top: 2px solid ${C.gray200};">
                   <td style="padding: 12px 8px; font-weight: 700;">합계</td>
                   <td style="padding: 8px 6px; text-align: center; font-weight: 700;">${memberStats.reduce((sum, m) => sum + m.sellerPipeline.total, 0)}</td>
-                  <td style="padding: 8px 6px; text-align: center; font-weight: 700; color: ${C.blue};">${memberStats.reduce((sum, m) => sum + m.sellerPipeline.contacted, 0)}</td>
-                  <td style="padding: 8px 6px; text-align: center; font-weight: 700; color: ${C.yellow};">${memberStats.reduce((sum, m) => sum + m.sellerPipeline.onboarded, 0)}</td>
-                  <td style="padding: 8px 6px; text-align: center; font-weight: 700;">${memberStats.reduce((sum, m) => sum + m.sellerPipeline.documented, 0)}</td>
-                  <td style="padding: 8px 6px; text-align: center; font-weight: 700; color: #B45309;">${memberStats.reduce((sum, m) => sum + m.sellerPipeline.firstDeal, 0)}</td>
+                  <td style="padding: 8px 6px; text-align: center; font-weight: 700; color: ${C.green};">${memberStats.reduce((sum, m) => sum + m.sellerPipeline.proposed, 0)}</td>
+                  <td style="padding: 8px 6px; text-align: center; font-weight: 700; color: ${C.blue};">${memberStats.reduce((sum, m) => sum + m.sellerPipeline.onboarding, 0)}</td>
+                  <td style="padding: 8px 6px; text-align: center; font-weight: 700; color: #B45309;">${memberStats.reduce((sum, m) => sum + m.sellerPipeline.contracted, 0)}</td>
                   <td style="padding: 8px 6px; text-align: center; font-weight: 700;">${memberStats.reduce((sum, m) => sum + m.supplierPipeline.total, 0)}</td>
-                  <td style="padding: 8px 6px; text-align: center; font-weight: 700;">${memberStats.reduce((sum, m) => sum + m.supplierPipeline.hasProducts, 0)}</td>
+                  <td style="padding: 8px 6px; text-align: center; font-weight: 700; color: ${C.green};">${memberStats.reduce((sum, m) => sum + m.supplierPipeline.proposed, 0)}</td>
+                  <td style="padding: 8px 6px; text-align: center; font-weight: 700; color: ${C.blue};">${memberStats.reduce((sum, m) => sum + m.supplierPipeline.onboarding, 0)}</td>
                   <td style="padding: 8px 6px; text-align: center; font-weight: 700; color: #4338CA;">${memberStats.reduce((sum, m) => sum + m.supplierPipeline.contracted, 0)}</td>
                 </tr>
               </tfoot>


### PR DESCRIPTION
- 셀러/공급사 파이프라인: 리스트업 → 제안 → 온보딩 → 계약 (4단계로 변경)
- 컨택완료 체크박스를 온보딩으로 변경
- 유입경로 추적 추가: 아웃바운드(직접제안, 지인추천) / 인바운드(광고유입 등)
- 영업현황 파이프라인 테이블 새 구조 반영
- 기존 contacted 데이터와 호환성 유지