### PR TITLE
셀러/공급사 온보딩 체크리스트 개선

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -4918,7 +4918,7 @@ function openSupplierModal(supplier = null, bulk = false) {
           <div style="background: white; border-radius: 8px; padding: 12px;">
             <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;">
               <label class="form-label" style="margin: 0;">📋 서류 수령 체크리스트</label>
-              <div id="supplier-checklist-progress" style="font-size: 12px; color: var(--gray-500);">0/4 완료</div>
+              <div id="supplier-checklist-progress" style="font-size: 12px; color: var(--gray-500);">0/5 완료</div>
             </div>
             
             <!-- 진행률 바 -->
@@ -4926,23 +4926,29 @@ function openSupplierModal(supplier = null, bulk = false) {
               <div id="supplier-progress-bar" style="height: 100%; background: var(--success); border-radius: 3px; transition: width 0.3s ease; width: 0%;"></div>
             </div>
             
-            <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px;">
+            <div style="display: flex; flex-direction: column; gap: 8px;">
               <label style="display: flex; align-items: center; gap: 8px; cursor: pointer; padding: 10px; background: var(--gray-50); border-radius: 8px; border: 1px solid var(--gray-200); transition: all 0.15s ease;" class="checklist-item">
-                <input type="checkbox" id="supplier-has-product-info" ${s.hasProductInfo ? 'checked' : ''} onchange="updateSupplierProgress()" style="width: 20px; height: 20px; accent-color: var(--success);">
-                <span style="font-size: 13px; font-weight: 500;">📦 상품등록</span>
+                <input type="checkbox" id="supplier-has-onboarding" ${s.hasOnboardingGuide ? 'checked' : ''} onchange="updateSupplierProgress()" style="width: 20px; height: 20px; accent-color: var(--success);">
+                <span style="font-size: 13px; font-weight: 500;">📘 온보딩 가이드 전달</span>
               </label>
-              <label style="display: flex; align-items: center; gap: 8px; cursor: pointer; padding: 10px; background: var(--gray-50); border-radius: 8px; border: 1px solid var(--gray-200); transition: all 0.15s ease;" class="checklist-item">
-                <input type="checkbox" id="supplier-has-business-license" ${s.hasBusinessLicense ? 'checked' : ''} onchange="updateSupplierProgress()" style="width: 20px; height: 20px; accent-color: var(--success);">
-                <span style="font-size: 13px; font-weight: 500;">🏢 사업자</span>
-              </label>
-              <label style="display: flex; align-items: center; gap: 8px; cursor: pointer; padding: 10px; background: var(--gray-50); border-radius: 8px; border: 1px solid var(--gray-200); transition: all 0.15s ease;" class="checklist-item">
-                <input type="checkbox" id="supplier-has-bank-account" ${s.hasBankAccount ? 'checked' : ''} onchange="updateSupplierProgress()" style="width: 20px; height: 20px; accent-color: var(--success);">
-                <span style="font-size: 13px; font-weight: 500;">🏦 통장</span>
-              </label>
-              <label style="display: flex; align-items: center; gap: 8px; cursor: pointer; padding: 10px; background: var(--gray-50); border-radius: 8px; border: 1px solid var(--gray-200); transition: all 0.15s ease;" class="checklist-item">
-                <input type="checkbox" id="supplier-has-contract" ${s.hasContract ? 'checked' : ''} onchange="updateSupplierProgress()" style="width: 20px; height: 20px; accent-color: var(--success);">
-                <span style="font-size: 13px; font-weight: 500;">📝 계약</span>
-              </label>
+              <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px;">
+                <label style="display: flex; align-items: center; gap: 8px; cursor: pointer; padding: 10px; background: var(--gray-50); border-radius: 8px; border: 1px solid var(--gray-200); transition: all 0.15s ease;" class="checklist-item">
+                  <input type="checkbox" id="supplier-has-product-info" ${s.hasProductInfo ? 'checked' : ''} onchange="updateSupplierProgress()" style="width: 20px; height: 20px; accent-color: var(--success);">
+                  <span style="font-size: 13px; font-weight: 500;">📦 상품등록</span>
+                </label>
+                <label style="display: flex; align-items: center; gap: 8px; cursor: pointer; padding: 10px; background: var(--gray-50); border-radius: 8px; border: 1px solid var(--gray-200); transition: all 0.15s ease;" class="checklist-item">
+                  <input type="checkbox" id="supplier-has-business-license" ${s.hasBusinessLicense ? 'checked' : ''} onchange="updateSupplierProgress()" style="width: 20px; height: 20px; accent-color: var(--success);">
+                  <span style="font-size: 13px; font-weight: 500;">🏢 사업자</span>
+                </label>
+                <label style="display: flex; align-items: center; gap: 8px; cursor: pointer; padding: 10px; background: var(--gray-50); border-radius: 8px; border: 1px solid var(--gray-200); transition: all 0.15s ease;" class="checklist-item">
+                  <input type="checkbox" id="supplier-has-bank-account" ${s.hasBankAccount ? 'checked' : ''} onchange="updateSupplierProgress()" style="width: 20px; height: 20px; accent-color: var(--success);">
+                  <span style="font-size: 13px; font-weight: 500;">🏦 통장</span>
+                </label>
+                <label style="display: flex; align-items: center; gap: 8px; cursor: pointer; padding: 10px; background: var(--gray-50); border-radius: 8px; border: 1px solid var(--gray-200); transition: all 0.15s ease;" class="checklist-item">
+                  <input type="checkbox" id="supplier-has-contract" ${s.hasContract ? 'checked' : ''} onchange="updateSupplierProgress()" style="width: 20px; height: 20px; accent-color: var(--success);">
+                  <span style="font-size: 13px; font-weight: 500;">📝 계약</span>
+                </label>
+              </div>
             </div>
             
             <!-- 구글 드라이브 바로가기 버튼 -->
@@ -5018,9 +5024,10 @@ function openSupplierModal(supplier = null, bulk = false) {
 
 // ========== 체크리스트 진행률 함수 ==========
 
-// 공급사 체크리스트 진행률 업데이트 (4개 항목)
+// 공급사 체크리스트 진행률 업데이트 (5개 항목)
 function updateSupplierProgress() {
   const checkboxes = [
+    'supplier-has-onboarding',
     'supplier-has-product-info',
     'supplier-has-business-license',
     'supplier-has-bank-account',
@@ -5676,7 +5683,8 @@ function submitSupplierForm(e, id) {
     inquiryMethod: document.getElementById('supplier-inquiry').value,
     contractStatus: document.getElementById('supplier-contract-status').value,
     bankAccount: document.getElementById('supplier-bank-account').value,
-    // 서류 수령 체크박스 (4개 항목)
+    // 서류 수령 체크박스 (5개 항목)
+    hasOnboardingGuide: document.getElementById('supplier-has-onboarding')?.checked || false,
     hasProductInfo: document.getElementById('supplier-has-product-info')?.checked || false,
     hasBusinessLicense: document.getElementById('supplier-has-business-license')?.checked || false,
     hasBankAccount: document.getElementById('supplier-has-bank-account')?.checked || false,
@@ -6037,14 +6045,14 @@ function openSellerModal(seller = null, bulk = false) {
         ${isEdit ? `
         <div style="background: var(--primary-light); border-radius: 8px; padding: 16px; margin-bottom: 12px; border: 1px solid var(--primary);">
           <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;">
-            <h3 style="font-size: 13px; color: var(--primary); font-weight: 600; margin: 0;">🎯 셀러 관리 여정</h3>
+            <h3 style="font-size: 13px; color: var(--primary); font-weight: 600; margin: 0;">🤝 온보딩 체크리스트</h3>
             <div id="seller-journey-progress" style="font-size: 12px; color: var(--primary); font-weight: 600;">0/5 완료</div>
           </div>
-          
+
           <div style="display: flex; flex-direction: column; gap: 6px; margin-bottom: 12px;">
             <label style="display: flex; align-items: center; gap: 10px; cursor: pointer; padding: 8px 12px; background: white; border-radius: 6px; border: 1px solid var(--gray-200);" class="seller-journey-item">
               <input type="checkbox" id="seller-journey-contact" ${s.journeyFirstContact ? 'checked' : ''} onchange="updateSellerJourneyProgress()" style="width: 16px; height: 16px; accent-color: var(--primary);">
-              <span style="font-size: 13px;">📞 첫 미팅/연락</span>
+              <span style="font-size: 13px;">📞 첫 컨택/미팅</span>
             </label>
             <label style="display: flex; align-items: center; gap: 10px; cursor: pointer; padding: 8px 12px; background: white; border-radius: 6px; border: 1px solid var(--gray-200);" class="seller-journey-item">
               <input type="checkbox" id="seller-journey-onboard" ${s.journeyOnboarding ? 'checked' : ''} onchange="updateSellerJourneyProgress()" style="width: 16px; height: 16px; accent-color: var(--primary);">
@@ -6052,19 +6060,38 @@ function openSellerModal(seller = null, bulk = false) {
             </label>
             <label style="display: flex; align-items: center; gap: 10px; cursor: pointer; padding: 8px 12px; background: white; border-radius: 6px; border: 1px solid var(--gray-200);" class="seller-journey-item">
               <input type="checkbox" id="seller-journey-docs" ${s.journeyDocuments ? 'checked' : ''} onchange="updateSellerJourneyProgress()" style="width: 16px; height: 16px; accent-color: var(--primary);">
-              <span style="font-size: 13px;">📄 서류 수령 완료</span>
+              <span style="font-size: 13px;">📄 입점신청서 수령</span>
             </label>
             <label style="display: flex; align-items: center; gap: 10px; cursor: pointer; padding: 8px 12px; background: white; border-radius: 6px; border: 1px solid var(--gray-200);" class="seller-journey-item">
-              <input type="checkbox" id="seller-journey-first-deal" ${s.journeyFirstDeal ? 'checked' : ''} onchange="updateSellerJourneyProgress()" style="width: 16px; height: 16px; accent-color: var(--primary);">
+              <input type="checkbox" id="seller-journey-bank" ${s.journeyBankInfo ? 'checked' : ''} onchange="updateSellerJourneyProgress()" style="width: 16px; height: 16px; accent-color: var(--primary);">
+              <span style="font-size: 13px;">🏦 계좌정보 수령</span>
+            </label>
+            <label style="display: flex; align-items: center; gap: 10px; cursor: pointer; padding: 8px 12px; background: white; border-radius: 6px; border: 1px solid var(--gray-200);" class="seller-journey-item">
+              <input type="checkbox" id="seller-journey-id" ${s.journeyIdCard ? 'checked' : ''} onchange="updateSellerJourneyProgress()" style="width: 16px; height: 16px; accent-color: var(--primary);">
+              <span style="font-size: 13px;">🪪 신분증 수령</span>
+            </label>
+          </div>
+        </div>
+
+        <!-- 사후관리 체크리스트 -->
+        <div style="background: #f0fdf4; border-radius: 8px; padding: 16px; margin-bottom: 12px; border: 1px solid #86efac;">
+          <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;">
+            <h3 style="font-size: 13px; color: #16a34a; font-weight: 600; margin: 0;">📊 사후관리</h3>
+            <div id="seller-aftercare-progress" style="font-size: 12px; color: #16a34a; font-weight: 600;">0/2 완료</div>
+          </div>
+
+          <div style="display: flex; flex-direction: column; gap: 6px; margin-bottom: 12px;">
+            <label style="display: flex; align-items: center; gap: 10px; cursor: pointer; padding: 8px 12px; background: white; border-radius: 6px; border: 1px solid var(--gray-200);" class="seller-aftercare-item">
+              <input type="checkbox" id="seller-journey-first-deal" ${s.journeyFirstDeal ? 'checked' : ''} onchange="updateSellerAftercareProgress()" style="width: 16px; height: 16px; accent-color: #16a34a;">
               <span style="font-size: 13px;">🛒 첫 공구 진행</span>
             </label>
-            <label style="display: flex; align-items: center; gap: 10px; cursor: pointer; padding: 8px 12px; background: white; border-radius: 6px; border: 1px solid var(--gray-200);" class="seller-journey-item">
-              <input type="checkbox" id="seller-journey-feedback" ${s.journeyFeedback ? 'checked' : ''} onchange="updateSellerJourneyProgress()" style="width: 16px; height: 16px; accent-color: var(--primary);">
+            <label style="display: flex; align-items: center; gap: 10px; cursor: pointer; padding: 8px 12px; background: white; border-radius: 6px; border: 1px solid var(--gray-200);" class="seller-aftercare-item">
+              <input type="checkbox" id="seller-journey-feedback" ${s.journeyFeedback ? 'checked' : ''} onchange="updateSellerAftercareProgress()" style="width: 16px; height: 16px; accent-color: #16a34a;">
               <span style="font-size: 13px;">📊 성과 피드백</span>
             </label>
           </div>
-          
-          <button type="button" onclick="generateSellerTasksFromJourney('${s.id}', '${s.name.replace(/'/g, "\\'")}')" style="width: 100%; background: var(--primary); color: white; border: none; padding: 10px; border-radius: 8px; cursor: pointer; font-size: 13px; font-weight: 600;">
+
+          <button type="button" onclick="generateSellerTasksFromJourney('${s.id}', '${s.name.replace(/'/g, "\\'")}')" style="width: 100%; background: #16a34a; color: white; border: none; padding: 10px; border-radius: 8px; cursor: pointer; font-size: 13px; font-weight: 600;">
             📋 미완료 항목 → 업무로 생성
           </button>
         </div>
@@ -6294,10 +6321,13 @@ function submitSellerForm(e, id) {
     // 서류 체크리스트 (민증, 통장만)
     hasIdCard: document.getElementById('seller-has-id-card')?.checked || false,
     hasBankAccount: document.getElementById('seller-has-bank-account')?.checked || false,
-    // 셀러 여정 체크리스트
+    // 셀러 온보딩 체크리스트
     journeyFirstContact: document.getElementById('seller-journey-contact')?.checked || false,
     journeyOnboarding: document.getElementById('seller-journey-onboard')?.checked || false,
     journeyDocuments: document.getElementById('seller-journey-docs')?.checked || false,
+    journeyBankInfo: document.getElementById('seller-journey-bank')?.checked || false,
+    journeyIdCard: document.getElementById('seller-journey-id')?.checked || false,
+    // 셀러 사후관리 체크리스트
     journeyFirstDeal: document.getElementById('seller-journey-first-deal')?.checked || false,
     journeyFeedback: document.getElementById('seller-journey-feedback')?.checked || false,
   };
@@ -32368,6 +32398,35 @@ function updateSellerJourneyProgress() {
   if (progressEl) {
     progressEl.textContent = checked + '/' + total + ' 완료';
     progressEl.style.color = checked === total ? 'var(--success)' : 'var(--primary)';
+  }
+}
+
+// 셀러 사후관리 진행률 업데이트
+function updateSellerAftercareProgress() {
+  var checkboxes = document.querySelectorAll('.seller-aftercare-item input[type="checkbox"]');
+  var total = checkboxes.length;
+  var checked = 0;
+  checkboxes.forEach(function(cb) {
+    if (cb.checked) checked++;
+    var label = cb.closest('.seller-aftercare-item');
+    if (label) {
+      if (cb.checked) {
+        label.style.background = '#dcfce7';
+        label.style.borderColor = '#16a34a';
+        label.querySelector('span').style.textDecoration = 'line-through';
+        label.querySelector('span').style.color = 'var(--gray-500)';
+      } else {
+        label.style.background = 'white';
+        label.style.borderColor = 'var(--gray-200)';
+        label.querySelector('span').style.textDecoration = 'none';
+        label.querySelector('span').style.color = 'var(--gray-900)';
+      }
+    }
+  });
+  var progressEl = document.getElementById('seller-aftercare-progress');
+  if (progressEl) {
+    progressEl.textContent = checked + '/' + total + ' 완료';
+    progressEl.style.color = checked === total ? '#16a34a' : '#16a34a';
   }
 }
 


### PR DESCRIPTION
셀러 DB:
- 온보딩 체크리스트 (5개): 첫 컨택/미팅, 온보딩 가이드 전달, 입점신청서 수령, 계좌정보 수령, 신분증 수령
- 사후관리 체크리스트 (2개): 첫 공구 진행, 성과 피드백
- journeyBankInfo, journeyIdCard 필드 추가

공급사 DB:
- 온보딩 가이드 전달 체크박스 추가 (hasOnboardingGuide)
- 체크리스트 5개로 확장