### PR TITLE
카페24 정산 미리보기 마진율 0% 인식 버그 수정

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -9527,18 +9527,31 @@ function updateSettlementPreview() {
     if (!deal) return;
 
     // 🎯 상품별 마진율 가져오기: group.marginRate > selectedProducts에서 매칭 > deal.sellerMarginRate
-    let productMarginRate = group.marginRate || 0;
+    // 마진율 0%도 유효한 값으로 처리
+    let productMarginRate = (group.marginRate !== undefined && group.marginRate !== null && group.marginRate !== '')
+      ? Number(group.marginRate)
+      : null;
 
     // group.marginRate가 없으면 selectedProducts에서 찾기
-    if (!productMarginRate && deal.selectedProducts?.length > 0) {
+    if (productMarginRate === null && deal.selectedProducts?.length > 0) {
       // 상품명으로 매칭
       const matchedProduct = deal.selectedProducts.find(p =>
         p.productName && group.productName &&
         (p.productName.includes(group.productName) || group.productName.includes(p.productName))
       );
-      productMarginRate = matchedProduct?.marginRate || deal.sellerMarginRate || 20;
+      if (matchedProduct && matchedProduct.marginRate !== undefined && matchedProduct.marginRate !== null && matchedProduct.marginRate !== '') {
+        productMarginRate = Number(matchedProduct.marginRate);
+      } else if (deal.sellerMarginRate !== undefined && deal.sellerMarginRate !== null && deal.sellerMarginRate !== '') {
+        productMarginRate = Number(deal.sellerMarginRate);
+      } else {
+        productMarginRate = 20;
+      }
     }
-    if (!productMarginRate) productMarginRate = deal.sellerMarginRate || 20;
+    if (productMarginRate === null) {
+      productMarginRate = (deal.sellerMarginRate !== undefined && deal.sellerMarginRate !== null && deal.sellerMarginRate !== '')
+        ? Number(deal.sellerMarginRate)
+        : 20;
+    }
 
     // 🎯 상품별 공급단가 가져오기
     let productSupplyPrice = group.supplyPrice || 0;


### PR DESCRIPTION
문제: 공구에 마진율 0% 설정해도 정산 미리보기에서 20%로 표시됨
원인: productMarginRate가 0일 때 falsy로 처리되어 기본값 20% 적용

수정 내용:
- 9530-9554라인: null 체크로 변경하여 0%도 유효한 값으로 처리
- group.marginRate, matchedProduct.marginRate, deal.sellerMarginRate 모두 명시적 체크