### PR TITLE
카페24 엑셀 파싱 시 상품구매금액(KRW) 컬럼 우선 적용

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -8920,7 +8920,11 @@ async function parseCafe24Excel(input) {
       const productNameBasic = (row['주문상품명(기본)'] || row['상품명(기본)'] || row['상품명'] || '').trim();
       const productOption = (row['주문상품명(옵션포함)'] || row['상품명(옵션포함)'] || row['옵션정보'] || '').trim();
       const quantity = parseInt(row['수량'] || row['주문수량'] || row['상품수량']) || 1;
-      const unitPrice = parseCafe24Amount(row['판매가'] || row['상품가격'] || row['상품금액'] || 0);
+      // 🎯 상품구매금액(KRW) = 실제 SKU 기준 공동구매 판매가격 (우선 사용)
+      const unitPrice = parseCafe24Amount(
+        row['상품구매금액(KRW)'] || row['상품구매금액'] ||  // 실제 SKU 기준 판매가 (우선)
+        row['판매가'] || row['상품가격'] || row['상품금액'] || 0
+      );
       // 총주문금액: 카페24 실제 컬럼명 포함 (KRW 표기 등)
       const totalAmount = parseCafe24Amount(
         row['총 주문금액(KRW)'] || row['총 결제금액(KRW)'] ||  // 카페24 실제 컬럼명
@@ -27678,8 +27682,11 @@ async function uploadCafe24Excel(event) {
         // 🎯 수량 파싱
         const quantity = parseInt(row['수량'] || row['주문수량'] || 1) || 1;
         
-        // 🎯 단가 파싱
-        const unitPrice = parseCafe24Amount(row['판매가'] || row['단가'] || 0);
+        // 🎯 단가 파싱 (상품구매금액 = 실제 SKU 기준 공동구매 판매가격)
+        const unitPrice = parseCafe24Amount(
+          row['상품구매금액(KRW)'] || row['상품구매금액'] ||  // 실제 SKU 기준 판매가 (우선)
+          row['판매가'] || row['단가'] || 0
+        );
         
         // 결제금액 파싱
         const totalAmount = parseCafe24Amount(row['총 결제금액(KRW)'] || row['총 결제금액'] || row['총주문금액'] || 0);


### PR DESCRIPTION
변경 내용:
- 8923라인: unitPrice 파싱 시 '상품구매금액(KRW)' 우선 사용
- 27686라인: 동일하게 '상품구매금액(KRW)' 우선 사용

상품구매금액(KRW)은 실제 SKU 기준 공동구매 판매가격으로,
기존 '판매가' 컬럼보다 정확한 정산 계산 가능