### PR TITLE
카페24 엑셀 행별 개별 처리 수정

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -8906,10 +8906,11 @@ async function parseCafe24Excel(input) {
       const row = rows[i];
 
       const orderId = row['주문번호'] || '';
-      const productNo = row['상품번호'] || (i + 1);
+      const productNo = row['상품번호'] || '';
       if (!orderId) continue;
 
-      const docId = `${orderId}_${productNo}`;
+      // 🎯 docId에 행 인덱스 포함: 같은 주문+상품번호라도 다른 SKU면 개별 처리
+      const docId = `${orderId}_${productNo}_${i}`;
       if (orderMap.has(docId)) continue;
 
       // 데이터 추출 (여러 가능한 컬럼명 지원)


### PR DESCRIPTION
- docId에 행 인덱스(i) 포함하여 같은 주문번호+상품번호라도 모든 행 처리
- 기존: 같은 주문의 여러 SKU가 중복으로 스킵됨
- 수정: 모든 행이 개별 처리되어 정확한 SKU 수 계산