### PR TITLE
카페24 상품구매금액 계산 수정 - 이미 행 총액임

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -9062,10 +9062,11 @@ async function parseCafe24Excel(input) {
         }
       }
 
-      // 🎯 그룹화 (상품코드 + 단가 기준) - 같은 상품이라도 가격이 다르면 다른 SKU
-      // unitPrice를 포함해서 38,800원 배도라지와 45,800원 배도라지를 다른 그룹으로 처리
+      // 🎯 그룹화 (상품코드 + 실제 단가 기준)
+      // 상품구매금액(KRW)는 이미 단가×수량 반영된 행 총액이므로, 실제 단가 = 상품구매금액 / 수량
+      const actualUnitPrice = quantity > 0 ? Math.round(unitPrice / quantity) : unitPrice;
       const baseKey = productCode || productOption || productNameBasic;
-      const groupKey = `${baseKey}_${unitPrice}`;
+      const groupKey = `${baseKey}_${actualUnitPrice}`;
       if (!cafe24GroupedData[groupKey]) {
         cafe24GroupedData[groupKey] = {
           productCode: productCode, // 자체상품코드
@@ -9074,7 +9075,7 @@ async function parseCafe24Excel(input) {
           productOption: productOption,
           supplier: supplierName,
           sellerName: sellerName,
-          unitPrice: unitPrice,  // 🎯 SKU 단가 (그룹 구분용)
+          unitPrice: actualUnitPrice,  // 🎯 실제 SKU 단가 (그룹 구분용)
           supplyPrice: matchedSupplyPrice, // 상품DB 매칭 공급단가
           marginRate: matchedMarginRate, // 상품DB 매칭 마진율
           orders: [],
@@ -9087,9 +9088,9 @@ async function parseCafe24Excel(input) {
         };
       }
 
-      // 🎯 SKU별 매출 = 단가 × 수량 (totalAmount는 주문 전체 금액이므로 사용 안함)
-      const skuSales = unitPrice * quantity;
-      cafe24GroupedData[groupKey].orders.push({ orderId, qty: quantity, price: skuSales, unitPrice });
+      // 🎯 SKU별 매출 = 상품구매금액 (이미 단가×수량 반영된 행 총액)
+      const skuSales = unitPrice;  // unitPrice = 상품구매금액(KRW) = 행 총액
+      cafe24GroupedData[groupKey].orders.push({ orderId, qty: quantity, price: skuSales, unitPrice: actualUnitPrice });
       cafe24GroupedData[groupKey].totalQty += quantity;
       cafe24GroupedData[groupKey].totalSales += skuSales;
       // 공급단가/마진율이 아직 없으면 업데이트


### PR DESCRIPTION
- 상품구매금액(KRW)는 이미 단가×수량 반영된 행 총액
- 실제 단가 = 상품구매금액 / 수량 으로 계산
- skuSales = 상품구매금액 (다시 수량 곱하지 않음)

예: 수량2, 상품구매금액 39,800원
- 기존: 39,800 × 2 = 79,600원 (잘못된 계산)
- 수정: 39,800원 (이미 총액)