### PR TITLE
공급사 정산서 공급가액/부가세 계산 수정

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -8203,18 +8203,22 @@ function viewSupplierSettlementDetail(settlementId) {
         </div>
 
         <!-- 요약 KPI -->
-        <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-bottom: 24px;">
+        <div style="display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-bottom: 24px;">
           <div style="background: #fef3c7; padding: 16px; border-radius: 12px; text-align: center;">
             <div style="font-size: 11px; color: #92400e; margin-bottom: 4px;">총 수량</div>
             <div style="font-size: 16px; font-weight: 700; color: #b45309;">${formatNumber(settlement.totalQuantity || 0)}개</div>
           </div>
           <div style="background: #fef3c7; padding: 16px; border-radius: 12px; text-align: center;">
-            <div style="font-size: 11px; color: #92400e; margin-bottom: 4px;">공급가액 (VAT 포함)</div>
-            <div style="font-size: 18px; font-weight: 800; color: #92400e;">${formatNumber(settlement.totalSupplyAmount || settlement.supplyAmount || 0)}원</div>
+            <div style="font-size: 11px; color: #92400e; margin-bottom: 4px;">공급가액</div>
+            <div style="font-size: 14px; font-weight: 600; color: #92400e;">${formatNumber(settlement.totalSupplyAmount || settlement.supplyAmount || 0)}원</div>
           </div>
           <div style="background: #fef3c7; padding: 16px; border-radius: 12px; text-align: center;">
-            <div style="font-size: 11px; color: #92400e; margin-bottom: 4px;">VAT</div>
-            <div style="font-size: 16px; font-weight: 700; color: #b45309;">${formatNumber(settlement.totalVatAmount || settlement.vatAmount || 0)}원</div>
+            <div style="font-size: 11px; color: #92400e; margin-bottom: 4px;">부가세(10%)</div>
+            <div style="font-size: 14px; font-weight: 600; color: #b45309;">${formatNumber(settlement.totalVatAmount || settlement.vatAmount || 0)}원</div>
+          </div>
+          <div style="background: #fde68a; padding: 16px; border-radius: 12px; text-align: center;">
+            <div style="font-size: 11px; color: #92400e; margin-bottom: 4px;">총 정산금액</div>
+            <div style="font-size: 18px; font-weight: 800; color: #92400e;">${formatNumber((settlement.totalSupplyAmount || settlement.supplyAmount || 0) + (settlement.totalVatAmount || settlement.vatAmount || 0))}원</div>
           </div>
         </div>
 
@@ -14954,10 +14958,10 @@ async function refreshManagementReport() {
         // 셀러 정산 (타사는 보통 마진 0원)
         const sellerPayment = Number(seller?.actualPayment) || 0;
 
-        // 공급사 정산
-        const supplyAmount = Number(supplier?.supplyAmount) || 0;
-        const vatAmount = Number(supplier?.vatAmount) || 0;
-        const supplierTotal = Number(supplier?.totalAmount) || (supplyAmount + vatAmount);
+        // 공급사 정산 (totalSupplyAmount/totalVatAmount 우선 사용)
+        const supplyAmount = Number(supplier?.totalSupplyAmount) || Number(supplier?.supplyAmount) || 0;
+        const vatAmount = Number(supplier?.totalVatAmount) || Number(supplier?.vatAmount) || 0;
+        const supplierTotal = supplyAmount + vatAmount;
 
         const settlementDt = seller?.settlementDate || supplier?.settlementDate || settlementDate;
 


### PR DESCRIPTION
수정 내용:
1. 공급사 정산서 상세 모달 - KPI 4칸으로 확장 (총 수량, 공급가액, 부가세, 총 정산금액)
2. 타사 상품 정산 테이블 - 필드명 fallback 추가 (totalSupplyAmount/totalVatAmount 우선 사용)

원인: 데이터가 totalSupplyAmount로 저장되지만 supplyAmount로 읽어서 0원 표시됨