### PR TITLE
공구 체크리스트 3단계 그룹화 구현

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -14237,7 +14237,27 @@ function renderDealManagement() {
     const journeyContent = deal.journeyContent === true;
     const journeyAdSetup = deal.journeyAdSetup === true;
     const journeySellerGuide = deal.journeySellerGuide === true;
-    
+    const journeyOrderSend = deal.journeyOrderSend === true;
+    const journeySellerSettle = deal.journeySellerSettle === true;
+    const journeySupplierSettle = deal.journeySupplierSettle === true;
+    const journeyComplete = deal.journeyComplete === true;
+
+    // 그룹별 진행률 계산
+    const prepItems = [journeySample, journeyPaymentLink, journeyContent, journeySellerGuide];
+    const prepDone = prepItems.filter(Boolean).length;
+    const prepTotal = prepItems.length;
+    const prepComplete = prepDone === prepTotal;
+
+    const marketItems = [journeyAdSetup];
+    const marketDone = marketItems.filter(Boolean).length;
+    const marketTotal = marketItems.length;
+    const marketComplete = marketDone === marketTotal;
+
+    const settleItems = [journeyOrderSend, journeySellerSettle, journeySupplierSettle, journeyComplete];
+    const settleDone = settleItems.filter(Boolean).length;
+    const settleTotal = settleItems.length;
+    const settleComplete = settleDone === settleTotal;
+
     return `
       <tr>
         <td style="text-align:center;">
@@ -14251,29 +14271,28 @@ function renderDealManagement() {
         </td>
         <td>${supplier?.name || '-'}</td>
         <td>${seller?.name || '-'}</td>
-        <td style="text-align:center;">
-          <button onclick="event.stopPropagation();quickToggleJourney('${deal.id}','journeySample',${!journeySample})" style="width:28px;height:28px;border-radius:6px;border:none;cursor:pointer;background:${journeySample ? '#0064FF' : '#E5E8EB'};color:${journeySample ? 'white' : '#8B95A1'};font-size:14px;" title="샘플 전달">
-            ${journeySample ? '✓' : ''}
+        <td style="text-align:center;position:relative;">
+          <button onclick="event.stopPropagation();toggleChecklistGroup(event,'${deal.id}','prep')"
+            style="padding:4px 8px;border-radius:6px;border:none;cursor:pointer;font-size:11px;font-weight:600;
+              background:${prepComplete ? '#2563eb' : '#dbeafe'};color:${prepComplete ? 'white' : '#2563eb'};"
+            title="준비 단계: 샘플전달, 결제링크, 콘텐츠, 가이드">
+            ${prepComplete ? '✓' : prepDone + '/' + prepTotal}
           </button>
         </td>
-        <td style="text-align:center;">
-          <button onclick="event.stopPropagation();quickToggleJourney('${deal.id}','journeyPaymentLink',${!journeyPaymentLink})" style="width:28px;height:28px;border-radius:6px;border:none;cursor:pointer;background:${journeyPaymentLink ? '#0064FF' : '#E5E8EB'};color:${journeyPaymentLink ? 'white' : '#8B95A1'};font-size:14px;" title="결제링크 전달">
-            ${journeyPaymentLink ? '✓' : ''}
+        <td style="text-align:center;position:relative;">
+          <button onclick="event.stopPropagation();toggleChecklistGroup(event,'${deal.id}','market')"
+            style="padding:4px 8px;border-radius:6px;border:none;cursor:pointer;font-size:11px;font-weight:600;
+              background:${marketComplete ? '#d97706' : '#fef3c7'};color:${marketComplete ? 'white' : '#d97706'};"
+            title="마케팅 단계: 광고 셋팅">
+            ${marketComplete ? '✓' : marketDone + '/' + marketTotal}
           </button>
         </td>
-        <td style="text-align:center;">
-          <button onclick="event.stopPropagation();quickToggleJourney('${deal.id}','journeyContent',${!journeyContent})" style="width:28px;height:28px;border-radius:6px;border:none;cursor:pointer;background:${journeyContent ? '#0064FF' : '#E5E8EB'};color:${journeyContent ? 'white' : '#8B95A1'};font-size:14px;" title="콘텐츠 전달">
-            ${journeyContent ? '✓' : ''}
-          </button>
-        </td>
-        <td style="text-align:center;">
-          <button onclick="event.stopPropagation();quickToggleJourney('${deal.id}','journeyAdSetup',${!journeyAdSetup})" style="width:28px;height:28px;border-radius:6px;border:none;cursor:pointer;background:${journeyAdSetup ? '#0064FF' : '#E5E8EB'};color:${journeyAdSetup ? 'white' : '#8B95A1'};font-size:14px;" title="광고 세팅">
-            ${journeyAdSetup ? '✓' : ''}
-          </button>
-        </td>
-        <td style="text-align:center;">
-          <button onclick="event.stopPropagation();quickToggleJourney('${deal.id}','journeySellerGuide',${!journeySellerGuide})" style="width:28px;height:28px;border-radius:6px;border:none;cursor:pointer;background:${journeySellerGuide ? '#0064FF' : '#E5E8EB'};color:${journeySellerGuide ? 'white' : '#8B95A1'};font-size:14px;" title="셀러 가이드">
-            ${journeySellerGuide ? '✓' : ''}
+        <td style="text-align:center;position:relative;">
+          <button onclick="event.stopPropagation();toggleChecklistGroup(event,'${deal.id}','settle')"
+            style="padding:4px 8px;border-radius:6px;border:none;cursor:pointer;font-size:11px;font-weight:600;
+              background:${settleComplete ? '#16a34a' : '#dcfce7'};color:${settleComplete ? 'white' : '#16a34a'};"
+            title="정산 단계: 발주서, 정산확인, 정산완료">
+            ${settleComplete ? '✓' : settleDone + '/' + settleTotal}
           </button>
         </td>
         <td style="text-align:center;"><span class="status-badge ${statusInfo.class}">${statusInfo.label}</span></td>
@@ -14284,19 +14303,17 @@ function renderDealManagement() {
     `;
   };
   
-  // 테이블 헤더 공통
+  // 테이블 헤더 공통 (3단계 그룹)
   const tableHeader = `
     <thead>
       <tr>
-        <th style="width:110px;text-align:center;white-space:nowrap;">D-Day</th>
+        <th style="width:80px;text-align:center;white-space:nowrap;">D-Day</th>
         <th>공구명</th>
         <th>공급사</th>
         <th>셀러</th>
-        <th style="text-align:center;width:50px;">샘플</th>
-        <th style="text-align:center;width:50px;">결제</th>
-        <th style="text-align:center;width:50px;">콘텐츠</th>
-        <th style="text-align:center;width:50px;">광고</th>
-        <th style="text-align:center;width:50px;">가이드</th>
+        <th style="text-align:center;width:90px;font-size:12px;background:#dbeafe;">📦 준비</th>
+        <th style="text-align:center;width:90px;font-size:12px;background:#fef3c7;">📺 마케팅</th>
+        <th style="text-align:center;width:90px;font-size:12px;background:#dcfce7;">💰 정산</th>
         <th style="text-align:center;">상태</th>
         <th style="text-align:center;">관리</th>
       </tr>
@@ -14376,7 +14393,7 @@ function renderDealManagement() {
     </div>
     
     <div style="margin-bottom: 24px; padding: 12px 16px; background: var(--gray-50); border-radius: 8px; font-size: 12px; color: var(--gray-600);">
-      💡 행을 클릭하거나 상세 버튼을 눌러 샘플전달, 결제링크전달, 컨텐츠전달을 관리하세요.
+      💡 <strong>준비/마케팅/정산</strong> 버튼을 클릭하면 하위 체크리스트가 나타납니다. (샘플전달은 파트너포털, 정산완료는 정산관리와 연동)
     </div>
     
     <!-- 완료된 공구 (열린 상태) -->
@@ -14407,12 +14424,127 @@ function renderDealManagement() {
 function toggleDealSection(sectionId) {
   const section = document.getElementById(sectionId + '-section');
   const arrow = document.getElementById(sectionId + '-arrow');
-  
+
   if (section) {
     const isHidden = section.style.display === 'none';
     section.style.display = isHidden ? 'block' : 'none';
     arrow.style.transform = isHidden ? 'rotate(180deg)' : 'rotate(0deg)';
   }
+}
+
+// 체크리스트 그룹 팝업 토글
+function toggleChecklistGroup(event, dealId, groupType) {
+  event.stopPropagation();
+
+  // 기존 팝업 제거
+  const existingPopup = document.getElementById('checklist-group-popup');
+  if (existingPopup) existingPopup.remove();
+
+  const deal = state.deals.find(d => d.id === dealId);
+  if (!deal) return;
+
+  // 그룹별 체크리스트 정의
+  const groups = {
+    prep: {
+      title: '📦 준비 단계',
+      color: '#2563eb',
+      bgColor: '#dbeafe',
+      items: [
+        { key: 'journeySample', label: '샘플 전달', desc: '공급사로부터 샘플 수령 (파트너 포털 연동)' },
+        { key: 'journeyPaymentLink', label: '결제링크 전달', desc: '셀러에게 결제 링크 전달' },
+        { key: 'journeyContent', label: '콘텐츠 전달', desc: '캔바로 제작한 콘텐츠 (선택)' },
+        { key: 'journeySellerGuide', label: '판매 가이드 전달', desc: '상품 맞춤 컨텐츠 제작 가이드' }
+      ]
+    },
+    market: {
+      title: '📺 마케팅 단계',
+      color: '#d97706',
+      bgColor: '#fef3c7',
+      items: [
+        { key: 'journeyAdSetup', label: '광고 셋팅', desc: '메타 광고 캠페인 설정' }
+      ]
+    },
+    settle: {
+      title: '💰 정산 단계',
+      color: '#16a34a',
+      bgColor: '#dcfce7',
+      items: [
+        { key: 'journeyOrderSend', label: '발주서 전달', desc: '공급사에게 발주서 전달' },
+        { key: 'journeySellerSettle', label: '셀러 정산확인', desc: '셀러용 정산서 제작 및 전달' },
+        { key: 'journeySupplierSettle', label: '공급사 정산확인', desc: '공급사용 정산서 제작 및 전달' },
+        { key: 'journeyComplete', label: '정산 완료', desc: '모든 정산 완료 (정산관리 연동)' }
+      ]
+    }
+  };
+
+  const group = groups[groupType];
+  if (!group) return;
+
+  // 팝업 위치 계산
+  const rect = event.target.getBoundingClientRect();
+  const popup = document.createElement('div');
+  popup.id = 'checklist-group-popup';
+  popup.style.cssText = `
+    position: fixed;
+    top: ${rect.bottom + 8}px;
+    left: ${Math.max(rect.left - 100, 10)}px;
+    width: 280px;
+    background: white;
+    border-radius: 12px;
+    box-shadow: 0 8px 32px rgba(0,0,0,0.2);
+    z-index: 10000;
+    overflow: hidden;
+    border: 1px solid ${group.bgColor};
+  `;
+
+  popup.innerHTML = `
+    <div style="background: ${group.bgColor}; padding: 12px 16px; border-bottom: 1px solid ${group.color}20;">
+      <div style="font-weight: 700; color: ${group.color}; font-size: 14px;">${group.title}</div>
+      <div style="font-size: 11px; color: ${group.color}80; margin-top: 2px;">${deal.title}</div>
+    </div>
+    <div style="padding: 8px;">
+      ${group.items.map(item => `
+        <label style="display: flex; align-items: flex-start; gap: 10px; padding: 10px 8px; cursor: pointer; border-radius: 8px; margin-bottom: 4px; background: ${deal[item.key] ? group.bgColor : 'transparent'};"
+          onmouseover="this.style.background='${group.bgColor}'" onmouseout="this.style.background='${deal[item.key] ? group.bgColor : 'transparent'}'">
+          <input type="checkbox" ${deal[item.key] ? 'checked' : ''}
+            onchange="quickToggleJourney('${dealId}','${item.key}',this.checked);setTimeout(()=>document.getElementById('checklist-group-popup')?.remove(),300)"
+            style="width: 18px; height: 18px; accent-color: ${group.color}; flex-shrink: 0; margin-top: 2px; cursor: pointer;">
+          <div>
+            <div style="font-weight: 600; font-size: 13px; color: #333;">${item.label}</div>
+            <div style="font-size: 11px; color: #666; margin-top: 2px;">${item.desc}</div>
+          </div>
+        </label>
+      `).join('')}
+    </div>
+    <div style="padding: 8px 12px 12px; border-top: 1px solid #eee;">
+      <button onclick="document.getElementById('checklist-group-popup').remove()"
+        style="width: 100%; padding: 8px; background: #f3f4f6; border: none; border-radius: 6px; cursor: pointer; font-size: 12px; color: #666;">
+        닫기
+      </button>
+    </div>
+  `;
+
+  document.body.appendChild(popup);
+
+  // 화면 밖으로 나가지 않도록 조정
+  const popupRect = popup.getBoundingClientRect();
+  if (popupRect.right > window.innerWidth) {
+    popup.style.left = (window.innerWidth - popupRect.width - 10) + 'px';
+  }
+  if (popupRect.bottom > window.innerHeight) {
+    popup.style.top = (rect.top - popupRect.height - 8) + 'px';
+  }
+
+  // 바깥 클릭 시 닫기
+  setTimeout(() => {
+    const closeHandler = (e) => {
+      if (!popup.contains(e.target)) {
+        popup.remove();
+        document.removeEventListener('click', closeHandler);
+      }
+    };
+    document.addEventListener('click', closeHandler);
+  }, 100);
 }
 
 // 샘플 전달 상태 토글


### PR DESCRIPTION
1. 테이블 헤더 변경
   - 기존 5개 개별 컬럼 → 3개 그룹 컬럼
   - 📦 준비 / 📺 마케팅 / 💰 정산

2. 그룹별 체크리스트 구성
   - 준비 단계: 샘플전달, 결제링크, 콘텐츠(선택), 판매가이드
   - 마케팅 단계: 광고 셋팅
   - 정산 단계: 발주서전달, 셀러정산, 공급사정산, 정산완료

3. UI/UX 개선
   - 그룹 버튼 클릭 시 하위 체크리스트 팝업 표시
   - 진행률 표시 (완료 시 ✓, 미완료 시 n/m)
   - 각 항목에 설명 추가 (파트너포털/정산관리 연동 안내)