### PR TITLE
파트너 포털 Best 판매 상품/셀러 TOP 데이터 연동 수정

### DIFF
--- a/login/index.html
+++ b/login/index.html
@@ -2343,9 +2343,9 @@ function renderDashboard(container) {
     // supplierSettlements에서 내 브랜드 데이터
     (state.supplierSettlements || []).forEach(ss => {
       if (!isMyBrand(ss)) return;
-      
+
       const targetMap = ss.isCompleted ? salesByProductCompleted : salesByProductPending;
-      
+
       const items = ss.items || ss.salesItems || [];
       if (items.length > 0) {
         items.forEach(item => {
@@ -2358,12 +2358,13 @@ function renderDashboard(container) {
           targetMap[productName].totalAmount += itemAmount;
         });
       } else {
-        const productName = ss.sellerName || '정산건';
+        // 🔧 FIX: items가 없을 때 brandName을 상품명으로, totalAmount || salesAmount 사용
+        const productName = ss.brandName || ss.sellerName || '정산건';
         if (!targetMap[productName]) {
           targetMap[productName] = { productName, totalQty: 0, totalAmount: 0 };
         }
-        targetMap[productName].totalQty += Number(ss.totalQuantity) || 1;
-        targetMap[productName].totalAmount += Number(ss.salesAmount) || 0;
+        targetMap[productName].totalQty += Number(ss.totalQuantity) || Number(ss.orderCount) || 1;
+        targetMap[productName].totalAmount += Number(ss.totalAmount) || Number(ss.salesAmount) || 0;
       }
     });
     
@@ -2448,26 +2449,28 @@ function renderDashboard(container) {
     // supplierSettlements에서 데이터 수집
     (state.supplierSettlements || []).forEach(ss => {
       if (!isMyBrand(ss)) return;
-      
-      const sellerName = ss.sellerName || '알 수 없음';
+
+      // 🔧 FIX: sellerName이 없으면 '셀러정보없음'으로 표시 (cafe24 정산은 sellerName이 없을 수 있음)
+      const sellerName = ss.sellerName || ss.brandName || '정산건';
       const parts = sellerName.split('/');
       const displayName = parts.length > 1 ? parts[1] : sellerName;
       const sellerKey = sellerName;
-      
+
       const seller = state.sellers.find(s => s.name && s.name.includes(displayName));
-      
+
       const targetMap = ss.isCompleted ? salesBySellerCompleted : salesBySellerPending;
-      
+
       if (!targetMap[sellerKey]) {
-        targetMap[sellerKey] = { 
-          sellerKey, 
-          sellerName: displayName, 
-          channelLink: seller?.channelLink || seller?.accountLink || '', 
-          totalAmount: 0, 
-          dealCount: 0 
+        targetMap[sellerKey] = {
+          sellerKey,
+          sellerName: displayName,
+          channelLink: seller?.channelLink || seller?.accountLink || '',
+          totalAmount: 0,
+          dealCount: 0
         };
       }
-      targetMap[sellerKey].totalAmount += Number(ss.salesAmount) || 0;
+      // 🔧 FIX: totalAmount || salesAmount 순서로 체크
+      targetMap[sellerKey].totalAmount += Number(ss.totalAmount) || Number(ss.salesAmount) || 0;
       targetMap[sellerKey].dealCount += 1;
     });
     
@@ -2475,28 +2478,29 @@ function renderDashboard(container) {
     (state.settlements || []).forEach(ss => {
       if (ss.productType !== 'inhouse') return;
       if (!isMyBrand(ss)) return;
-      
+
       const sellerName = ss.sellerName || '알 수 없음';
       const parts = sellerName.split('/');
       const displayName = parts.length > 1 ? parts[1] : sellerName;
       const sellerKey = sellerName;
-      
+
       const seller = state.sellers.find(s => s.name && s.name.includes(displayName));
-      
+
       // 자사 상품: isSellerCompleted 또는 isCompleted
       const isComplete = ss.isSellerCompleted || ss.isCompleted || false;
       const targetMap = isComplete ? salesBySellerCompleted : salesBySellerPending;
-      
+
       if (!targetMap[sellerKey]) {
-        targetMap[sellerKey] = { 
-          sellerKey, 
-          sellerName: displayName, 
-          channelLink: seller?.channelLink || seller?.accountLink || '', 
-          totalAmount: 0, 
-          dealCount: 0 
+        targetMap[sellerKey] = {
+          sellerKey,
+          sellerName: displayName,
+          channelLink: seller?.channelLink || seller?.accountLink || '',
+          totalAmount: 0,
+          dealCount: 0
         };
       }
-      targetMap[sellerKey].totalAmount += Number(ss.salesAmount) || 0;
+      // 🔧 FIX: totalAmount || salesAmount 순서로 체크
+      targetMap[sellerKey].totalAmount += Number(ss.totalAmount) || Number(ss.salesAmount) || 0;
       targetMap[sellerKey].dealCount += 1;
     });
     


### PR DESCRIPTION
문제: cafe24 정산 데이터에서 totalAmount 필드 사용,
      코드에서는 salesAmount만 조회하여 데이터 표시 안됨

수정 내용:
- Best 판매 상품 TOP: totalAmount || salesAmount 순서로 조회
- 많이 판매한 셀러 TOP: 동일하게 수정
- items 없을 때 brandName을 상품명으로 사용 (기존: sellerName)
- orderCount 필드도 수량으로 사용 가능하도록 추가