### PR TITLE
공급사 온보딩: '템플릿 주요 입력 항목' 안내 박스 제거

### DIFF
--- a/supplier/onboarding/index.html
+++ b/supplier/onboarding/index.html
@@ -354,15 +354,6 @@
                 </div>
                 <div class="step-content">
                     <div class="step-body"><div class="step-body-inner">
-                        <div class="required-box">
-                            <div class="required-title">템플릿 주요 입력 항목 (VAT 포함가 기준)</div>
-                            <div class="required-tags">
-                                <span class="required-tag">브랜드명</span><span class="required-tag">상품명</span><span class="required-tag">옵션명</span>
-                                <span class="required-tag">공급단가</span><span class="required-tag">정가</span><span class="required-tag">공동구매가</span>
-                                <span class="required-tag">재고수량</span><span class="required-tag">원산지</span><span class="required-tag">과세/면세</span><span class="required-tag">배송방식·배송비</span>
-                            </div>
-                            <div class="required-tip">💡 상품 카테고리(일반/식품/화장품/전기·생활·어린이/건강기능식품)에 맞는 시트를 골라 작성하고, 인증·표시 항목은 해당 시 반드시 기재해주세요.</div>
-                        </div>
                         <div class="choice-group">
                             <button type="button" class="choice-btn" id="btn-product-now" onclick="selectProductOption('now')">지금 등록하기</button>
                             <button type="button" class="choice-btn" id="btn-product-later" onclick="selectProductOption('later')">나중에 등록</button>


### PR DESCRIPTION
공급사 온보딩 상품정보 등록 영역에서 "템플릿 주요 입력 항목" 안내 박스를 제거합니다. (엑셀 템플릿 내용 변경에 따라 화면 상단 중복 안내 정리)

https://claude.ai/code/session_019rTVhVEf7Cv59UZ7kAdpft

---
_Generated by [Claude Code](https://claude.ai/code/session_019rTVhVEf7Cv59UZ7kAdpft)_