### PR TITLE
공급사 온보딩: 작성 방법·템플릿 다운로드 항상 노출, '중요' 박스 제거

### DIFF
--- a/supplier/onboarding/index.html
+++ b/supplier/onboarding/index.html
@@ -358,17 +358,16 @@
                             <button type="button" class="choice-btn" id="btn-product-now" onclick="selectProductOption('now')">지금 등록하기</button>
                             <button type="button" class="choice-btn" id="btn-product-later" onclick="selectProductOption('later')">나중에 등록</button>
                         </div>
+                        <div class="excel-guide">
+                            <div class="excel-guide-title">📋 작성 방법</div>
+                            <ol class="excel-guide-steps">
+                                <li>아래 <strong>엑셀 템플릿을 다운로드</strong>해주세요.</li>
+                                <li>상품 카테고리에 맞는 시트를 골라 <strong>옵션 단위로 한 행씩 작성</strong>해주세요.</li>
+                                <li>작성을 마친 파일을 아래에 <strong>업로드(첨부)</strong>해주세요.</li>
+                            </ol>
+                        </div>
+                        <a href="product-template.xlsx" download="모여라딜_공급사_상품등록_템플릿.xlsx" class="download-btn"><span>⬇️</span> 엑셀 템플릿 다운로드</a>
                         <div id="product-upload-section" style="display: none;">
-                            <div class="highlight-box"><strong>중요:</strong> 모든 단가는 <strong>VAT 포함가</strong>로 기재해주세요!</div>
-                            <div class="excel-guide">
-                                <div class="excel-guide-title">📋 작성 방법</div>
-                                <ol class="excel-guide-steps">
-                                    <li>아래 <strong>엑셀 템플릿을 다운로드</strong>해주세요.</li>
-                                    <li>상품 카테고리에 맞는 시트를 골라 <strong>옵션 단위로 한 행씩 작성</strong>해주세요.</li>
-                                    <li>작성을 마친 파일을 아래에 <strong>업로드(첨부)</strong>해주세요.</li>
-                                </ol>
-                            </div>
-                            <a href="product-template.xlsx" download="모여라딜_공급사_상품등록_템플릿.xlsx" class="download-btn"><span>⬇️</span> 엑셀 템플릿 다운로드</a>
                             <div class="upload-area" onclick="document.getElementById('file-excel').click()">
                                 <div class="upload-icon">📊</div><div class="upload-title">작성한 엑셀 파일 업로드</div><div class="upload-desc">클릭하여 파일 선택 (.xlsx, .xls, .csv)</div>
                                 <input type="file" id="file-excel" class="upload-input" accept=".xlsx,.xls,.csv" onchange="handleFileUpload(this, 'preview-excel')">


### PR DESCRIPTION
공급사 온보딩 상품정보 등록(Step 1) 화면 정리:

- **"작성 방법" 안내 + "엑셀 템플릿 다운로드" 버튼을 항상 노출** (기존에는 "지금 등록하기" 선택 시에만 표시되던 것을 단계 진입 시 바로 보이도록 변경)
- **"중요: 모든 단가는 VAT 포함가로 기재" 안내 박스 제거**
- "작성한 엑셀 파일 업로드" 영역은 기존대로 "지금 등록하기" 선택 시 노출

https://claude.ai/code/session_019rTVhVEf7Cv59UZ7kAdpft

---
_Generated by [Claude Code](https://claude.ai/code/session_019rTVhVEf7Cv59UZ7kAdpft)_