### PR TITLE
공급사 온보딩: 정산 안내를 2가지 정산 방식 + 공통 안내로 개편

### DIFF
--- a/supplier/onboarding/index.html
+++ b/supplier/onboarding/index.html
@@ -218,6 +218,30 @@
 
         .settlement-card { background: var(--bg-card); border: 1px solid var(--border-color); border-radius: var(--radius-lg); padding: 20px; margin-bottom: 20px; box-shadow: var(--shadow-sm); }
         .settlement-title { font-size: 15px; font-weight: 700; color: var(--text-primary); margin-bottom: 16px; display: flex; align-items: center; gap: 8px; }
+        .settlement-subtitle { font-size: 13px; color: var(--text-secondary); margin: -8px 0 18px; line-height: 1.6; }
+        .settlement-subtitle strong { color: var(--orange); }
+        .settle-method { border-radius: var(--radius-md); padding: 16px 18px; margin-bottom: 14px; }
+        .settle-method.buy { background: linear-gradient(135deg, rgba(249,115,22,0.07), rgba(251,191,36,0.07)); border: 1px solid rgba(249,115,22,0.18); }
+        .settle-method.group { background: linear-gradient(135deg, rgba(245,158,11,0.07), rgba(251,191,36,0.07)); border: 1px solid rgba(245,158,11,0.18); }
+        .settle-method-head { font-size: 14px; font-weight: 700; color: var(--text-primary); margin-bottom: 12px; display: flex; align-items: center; gap: 6px; }
+        .settle-row { font-size: 13px; color: var(--text-secondary); line-height: 1.6; margin-bottom: 8px; }
+        .settle-row:last-child { margin-bottom: 0; }
+        .settle-row strong { color: var(--text-primary); }
+        .settle-split { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-top: 12px; }
+        .settle-split-box { border-radius: var(--radius-sm); padding: 12px 14px; }
+        .settle-split-box.front { background: rgba(249,115,22,0.08); border: 1px solid rgba(249,115,22,0.2); }
+        .settle-split-box.back { background: rgba(34,197,94,0.08); border: 1px solid rgba(34,197,94,0.2); }
+        .settle-split-title { font-size: 13px; font-weight: 700; margin-bottom: 6px; }
+        .settle-split-box.front .settle-split-title { color: #ea580c; }
+        .settle-split-box.back .settle-split-title { color: #16a34a; }
+        .settle-split-box ul { list-style: none; }
+        .settle-split-box li { font-size: 12px; color: var(--text-secondary); line-height: 1.55; }
+        .settle-note { font-size: 12px; color: var(--text-muted); margin-top: 12px; line-height: 1.6; }
+        .settle-common-title { font-size: 14px; font-weight: 700; color: var(--text-primary); margin: 4px 0 12px; display: flex; align-items: center; gap: 6px; }
+        .settle-common-row { font-size: 13px; color: var(--text-secondary); line-height: 1.6; padding: 10px 0; border-top: 1px solid var(--border-color); }
+        .settle-common-row:first-of-type { border-top: none; padding-top: 0; }
+        .settle-common-row strong { color: var(--text-primary); margin-right: 6px; }
+        .settle-common-row a { color: var(--green); text-decoration: none; }
 
         /* 입점 후 여정 안내 */
         .journey-card { background: var(--bg-card); border: 1px solid var(--border-color); border-radius: var(--radius-lg); padding: 20px; margin-bottom: 20px; box-shadow: var(--shadow-sm); }
@@ -498,12 +522,47 @@
             </div>
 
             <div class="settlement-card">
-                <div class="settlement-title">💰 정산 안내</div>
-                <div class="info-box">
-                    <div class="info-item"><span class="info-bullet">•</span><span><strong>정산 시점:</strong> 공구마감 1일 후 기준, 3~7일 이내 입금</span></div>
-                    <div class="info-item"><span class="info-bullet">•</span><span><strong>정산 절차:</strong> 정산서 전달 → <strong style="color: var(--orange);">공급사 확인(승인)</strong> → 입금</span></div>
-                    <div class="info-item"><span class="info-bullet">•</span><span><strong>계산서 발행:</strong> 승인해주신 일자로 발행</span></div>
-                    <div class="info-item"><span class="info-bullet">•</span><span><strong>계산서 이메일:</strong> <a href="mailto:yoojin83@netformrnd.com">yoojin83@netformrnd.com</a></span></div>
+                <div class="settlement-title">💰 정산 방식은 2가지입니다</div>
+                <div class="settlement-subtitle">판매 물량과 방식에 따라 정산이 나뉩니다. 어떤 경우든 <strong>CS·반품은 모여라딜이 처리</strong>합니다.</div>
+
+                <div class="settle-method buy">
+                    <div class="settle-method-head">🛒 상시 매입 — 즉시 완납</div>
+                    <div class="settle-row"><strong>대상</strong> &nbsp;모여라딜이 직접 매입해 상시 판매하는 물량</div>
+                    <div class="settle-row"><strong>정산</strong> &nbsp;입고 검수 후 공급가 100% 즉시 완납</div>
+                    <div class="settle-row"><strong>반품·재고</strong> &nbsp;전량 모여라딜 보유 — 공급사 환수·부담 없음</div>
+                    <div class="settle-row"><strong>계산서</strong> &nbsp;매입 확정 기준 발행</div>
+                </div>
+
+                <div class="settle-method group">
+                    <div class="settle-method-head">🤝 공동구매 — 선금 70% / 잔금 30%</div>
+                    <div class="settle-row"><strong>대상</strong> &nbsp;셀러가 팔로워 대상으로 진행하는 한정수량 공동구매</div>
+                    <div class="settle-row"><strong>정산 시점</strong> &nbsp;공구 마감 1일 후 기준 입금</div>
+                    <div class="settle-split">
+                        <div class="settle-split-box front">
+                            <div class="settle-split-title">선금 70%</div>
+                            <ul>
+                                <li>공구 마감 1일 후 입금</li>
+                                <li>공급사 현금 흐름 우선</li>
+                            </ul>
+                        </div>
+                        <div class="settle-split-box back">
+                            <div class="settle-split-title">잔금 30%</div>
+                            <ul>
+                                <li>마감 후 7일 뒤 입금</li>
+                                <li>반품 발생 시 차감 후 지급</li>
+                                <li>반품 없으면 전액 입금</li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="settle-note">※ 대량 발주 특성상 반품 리스크를 함께 나눠, 빠른 선금과 안정적 정산을 동시에 보장합니다.</div>
+                </div>
+
+                <div style="margin-top: 20px; padding-top: 18px; border-top: 1px dashed var(--border-color);">
+                    <div class="settle-common-title">📋 공통 안내</div>
+                    <div class="settle-common-row"><strong>정산 절차</strong> 정산서 + 구매자 리스트 전달 → <strong style="color: var(--orange);">공급사 확인(승인)</strong> → 입금</div>
+                    <div class="settle-common-row"><strong>계산서 발행</strong> 승인해주신 일자로 발행</div>
+                    <div class="settle-common-row"><strong>계산서 이메일</strong> <a href="mailto:yoojin83@netformrnd.com">yoojin83@netformrnd.com</a></div>
+                    <div class="settle-common-row"><strong>CS · 반품</strong> 모든 고객 응대·교환·반품은 모여라딜이 1차 처리 (제품 하자 등만 별도 요청)</div>
                 </div>
             </div>
 


### PR DESCRIPTION
공급사 온보딩의 기존 "💰 정산 안내" 섹션을 새 내용으로 교체했습니다.

- 제목: "정산 방식은 2가지입니다" + 부제 (CS·반품은 모여라딜 처리)
- **상시 매입 — 즉시 완납** 카드 (대상/정산/반품·재고/계산서)
- **공동구매 — 선금 70% / 잔금 30%** 카드 (대상/정산 시점 + 선금·잔금 분할 박스 + 안내문)
- **공통 안내** (정산 절차 / 계산서 발행 / 계산서 이메일 / CS·반품)

https://claude.ai/code/session_019rTVhVEf7Cv59UZ7kAdpft

---
_Generated by [Claude Code](https://claude.ai/code/session_019rTVhVEf7Cv59UZ7kAdpft)_