### PR TITLE
공급사 온보딩: 입점 여정 타임라인 세로선·점 정렬 보정

### DIFF
--- a/supplier/onboarding/index.html
+++ b/supplier/onboarding/index.html
@@ -246,11 +246,11 @@
         /* 입점 후 여정 안내 */
         .journey-card { background: var(--bg-card); border: 1px solid var(--border-color); border-radius: var(--radius-lg); padding: 20px; margin-bottom: 20px; box-shadow: var(--shadow-sm); }
         .journey-title { font-size: 15px; font-weight: 700; color: var(--text-primary); margin-bottom: 16px; display: flex; align-items: center; gap: 8px; }
-        .journey-timeline { position: relative; padding-left: 24px; }
-        .journey-timeline::before { content: ''; position: absolute; left: 7px; top: 8px; bottom: 8px; width: 2px; background: var(--border-color); }
+        .journey-timeline { position: relative; padding-left: 26px; }
         .journey-step { position: relative; margin-bottom: 20px; }
         .journey-step:last-child { margin-bottom: 0; }
-        .journey-step-dot { position: absolute; left: -24px; top: 2px; width: 16px; height: 16px; border-radius: 50%; background: var(--accent-gradient); border: 3px solid var(--bg-card); }
+        .journey-step:not(:last-child)::before { content: ''; position: absolute; left: -20px; top: 10px; bottom: -23px; width: 2px; background: var(--border-color); }
+        .journey-step-dot { position: absolute; left: -26px; top: 3px; width: 14px; height: 14px; border-radius: 50%; background: var(--accent-gradient); border: 2px solid var(--bg-card); z-index: 1; }
         .journey-step-title { font-size: 13px; font-weight: 600; color: var(--text-primary); margin-bottom: 4px; }
         .journey-step-desc { font-size: 12px; color: var(--text-muted); line-height: 1.5; }
 


### PR DESCRIPTION
"입점 후 여정 안내" 타임라인의 세로선과 점(동그라미) 정렬이 어긋나 보이는 문제를 수정했습니다.

- 컨테이너 전체에 한 줄로 긋던 세로선(`.journey-timeline::before`)을 제거
- 각 단계의 점에서 다음 점까지 직접 잇는 연결선(`.journey-step:not(:last-child)::before`)으로 변경 → 항목 높이와 무관하게 항상 점 중심을 통과
- 점 크기/테두리/위치 미세 조정 및 z-index로 선 위에 점이 깔끔하게 표시되도록 보정

https://claude.ai/code/session_019rTVhVEf7Cv59UZ7kAdpft

---
_Generated by [Claude Code](https://claude.ai/code/session_019rTVhVEf7Cv59UZ7kAdpft)_