### PR TITLE
입점 신청: 하단에 '온보딩 이어서 작성하기' 버튼 추가

### DIFF
--- a/supplier/apply/index.html
+++ b/supplier/apply/index.html
@@ -329,6 +329,30 @@
             cursor: not-allowed;
         }
 
+        /* 온보딩 이어서 작성하기 버튼 */
+        .onboarding-continue-btn {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 6px;
+            width: 100%;
+            margin-top: 10px;
+            background: #fff;
+            color: #fe9f29;
+            font-size: 16px;
+            font-weight: 600;
+            padding: 16px;
+            border: 1px solid #fe9f29;
+            border-radius: 8px;
+            cursor: pointer;
+            transition: all 0.3s;
+            text-decoration: none;
+        }
+
+        .onboarding-continue-btn:hover {
+            background: #fff7ee;
+        }
+
         /* 성공 모달 - 다크 테마 */
         .success-modal {
             display: none;
@@ -737,6 +761,7 @@
                     </div>
 
                     <button type="submit" class="submit-btn" id="submitBtn">신청하기</button>
+                    <a href="/supplier/onboarding/" class="onboarding-continue-btn">온보딩 이어서 작성하기</a>
                 </form>
             </div>
         </div>


### PR DESCRIPTION
입점 신청(`/supplier/apply/`) 페이지 하단을 버튼 2개로 구성했습니다.

- 기존 **신청하기** 버튼(진한 색) 유지
- 그 아래 **온보딩 이어서 작성하기** 버튼 추가 (온보딩 색상, `/supplier/onboarding/`로 이동)

https://claude.ai/code/session_019rTVhVEf7Cv59UZ7kAdpft

---
_Generated by [Claude Code](https://claude.ai/code/session_019rTVhVEf7Cv59UZ7kAdpft)_