### PR TITLE
입점 신청 완료 모달: 서류 제출 유도 강화

### DIFF
--- a/supplier/apply/index.html
+++ b/supplier/apply/index.html
@@ -467,24 +467,21 @@
 
         .success-later-btn {
             width: 100%;
-            padding: 12px 20px;
+            margin-top: 4px;
+            padding: 6px 8px;
             background: transparent;
-            border: 1px solid rgba(255,255,255,0.2);
-            border-radius: 10px;
-            color: rgba(255,255,255,0.6);
-            font-size: 13px;
-            font-weight: 500;
+            border: none;
+            color: rgba(255,255,255,0.4);
+            font-size: 12px;
+            font-weight: 400;
+            text-decoration: underline;
+            text-underline-offset: 3px;
             cursor: pointer;
             transition: all 0.2s;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            gap: 6px;
         }
 
         .success-later-btn:hover {
-            border-color: rgba(255,255,255,0.4);
-            color: rgba(255,255,255,0.8);
+            color: rgba(255,255,255,0.7);
         }
 
         .close-btn {
@@ -775,19 +772,14 @@
                     <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
                 </svg>
             </div>
-            <h2>입점신청이 완료되었습니다!</h2>
-            <p>
-                소중한 신청 감사드립니다.<br>
-                영업일 기준 1~2일 내에<br>
-                담당자가 연락드리겠습니다.
-            </p>
+            <h2>신청 접수 완료!<br>마지막 한 단계가 남았어요</h2>
+            <p>소중한 신청 감사드립니다 🙏</p>
             <div class="success-doc-card" id="onboardingLinkSection">
-                <div class="success-doc-title">📋 서류 제출 준비가 되셨나요?</div>
-                <div class="success-doc-desc">담당자 연락 전에 미리 서류를 준비하시면<br>더 빠르게 진행됩니다.</div>
-                <button class="success-doc-btn" onclick="goToOnboarding()">📄 서류 제출하러 가기</button>
-                <button class="success-later-btn" id="copyOnboardingLinkBtn" onclick="copyOnboardingLink()">🔗 나중에 할래요 (링크 복사)</button>
+                <div class="success-doc-title">📄 서류까지 제출해야 입점 검토가 시작됩니다</div>
+                <div class="success-doc-desc">지금 바로 이어서 제출하면<br>가장 빠르게 진행돼요.</div>
+                <button class="success-doc-btn" onclick="goToOnboarding()">📄 서류 제출하고 완료하기</button>
+                <button class="success-later-btn" onclick="closeSuccessModal()">나중에 제출할게요</button>
             </div>
-            <button class="close-btn" onclick="closeSuccessModal()">확인</button>
         </div>
     </div>
     <div class="success-toast" id="successToast">✓ 온보딩 링크가 복사되었습니다</div>


### PR DESCRIPTION
입점신청 완료 모달을 서류 제출로 강하게 유도하도록 개편 ("필수 단계 강조" 방향).

- 제목: "신청 접수 완료! 마지막 한 단계가 남았어요"
- 본문: 감사 한 줄 + "서류까지 제출해야 입점 검토가 시작됩니다 / 지금 바로 이어서 제출하면 가장 빠르게 진행돼요"
- 기본 버튼: "📄 서류 제출하고 완료하기" (온보딩 이동)
- 우회 동선 약화: 기존 "나중에 할래요(링크 복사)" + "확인" 두 개 → 작은 텍스트 링크 "나중에 제출할게요" 하나로 축소

https://claude.ai/code/session_019rTVhVEf7Cv59UZ7kAdpft

---
_Generated by [Claude Code](https://claude.ai/code/session_019rTVhVEf7Cv59UZ7kAdpft)_