### PR TITLE
입점 신청: 상단 배너 중복 버튼 제거(안내 전용)

### DIFF
--- a/supplier/apply/index.html
+++ b/supplier/apply/index.html
@@ -529,7 +529,7 @@
             padding: 16px 20px;
             margin-bottom: 28px;
             display: flex;
-            align-items: center;
+            align-items: flex-start;
             gap: 12px;
         }
 
@@ -555,37 +555,15 @@
             line-height: 1.5;
         }
 
-        .already-applied-banner .banner-btn {
-            flex-shrink: 0;
-            background: #fe9f29;
-            color: #fff;
-            border: none;
-            padding: 10px 16px;
-            border-radius: 8px;
-            font-size: 13px;
-            font-weight: 600;
-            cursor: pointer;
-            transition: all 0.2s;
-            text-decoration: none;
-            white-space: nowrap;
-        }
-
-        .already-applied-banner .banner-btn:hover {
-            background: #e8900f;
-            transform: translateY(-1px);
+        .already-applied-banner .banner-desc strong {
+            color: #f97316;
+            font-weight: 700;
         }
 
         @media (max-width: 768px) {
             .already-applied-banner {
-                flex-direction: column;
-                text-align: center;
-                gap: 8px;
+                gap: 10px;
                 padding: 14px 16px;
-            }
-
-            .already-applied-banner .banner-btn {
-                width: 100%;
-                padding: 12px;
             }
         }
 
@@ -706,9 +684,8 @@
                 <span class="banner-icon">📋</span>
                 <div class="banner-text">
                     <div class="banner-title">이미 신청하셨나요?</div>
-                    <div class="banner-desc">연락처만 입력하면 바로 온보딩을 진행할 수 있습니다.</div>
+                    <div class="banner-desc">다시 작성하지 마시고 아래 <strong>‘온보딩 이어서 작성하기’</strong>로 바로 진행하세요.</div>
                 </div>
-                <a href="/supplier/onboarding/" class="banner-btn">온보딩 바로가기</a>
             </div>
 
             <div class="form-container">


### PR DESCRIPTION
옵션 C 적용: 입점 신청 상단 "이미 신청하셨나요?" 배너에서 하단과 중복되던 '온보딩 바로가기' 버튼을 제거하고, 안내 전용으로 변경했습니다.

- 큰 주황 버튼 삭제 + 관련 CSS 정리
- 안내 문구: "다시 작성하지 마시고 아래 '온보딩 이어서 작성하기'로 바로 진행하세요." (강조 부분 주황 처리)
- 이동은 하단 '온보딩 이어서 작성하기' 버튼으로 일원화

https://claude.ai/code/session_019rTVhVEf7Cv59UZ7kAdpft

---
_Generated by [Claude Code](https://claude.ai/code/session_019rTVhVEf7Cv59UZ7kAdpft)_