### PR TITLE
Add supplier/guide/index.html reels shooting guide page

### DIFF
--- a/supplier/guide/index.html
+++ b/supplier/guide/index.html
@@ -1,0 +1,448 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <title>릴스 촬영 가이드 · 모여라딜</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css">
+  <meta name="theme-color" content="#fc9600">
+  <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-app-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-auth-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-firestore-compat.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/9.22.0/firebase-storage-compat.js"></script>
+  <style>
+    :root{--brand:#fc9600;--brand-d:#e08600;--brand-l:#fff8f0;--ink:#191f28;--sub:#4e5968;--tert:#8b95a1;--line:#e5e8eb;--ok:#00c073;--okl:#ecfdf5;--bg:#f9fafb;}
+    *{box-sizing:border-box;margin:0;padding:0;}
+    body{font-family:'Pretendard',-apple-system,sans-serif;background:var(--bg);color:var(--ink);-webkit-font-smoothing:antialiased;}
+    .wrap{max-width:480px;margin:0 auto;padding-bottom:50px;}
+    .hero{background:#fff;padding:22px 18px 16px;border-bottom:1px solid var(--line);}
+    .hero .hi{font-size:13px;color:var(--tert);}
+    .hero .nm{font-size:23px;font-weight:800;margin:3px 0 8px;}
+    .hero .prod{display:flex;align-items:center;gap:8px;font-size:13px;color:var(--sub);background:var(--bg);border-radius:10px;padding:10px 12px;}
+    .steps{display:flex;gap:6px;padding:14px 18px 0;}
+    .stp{flex:1;text-align:center;font-size:11px;color:var(--tert);}
+    .stp .dot{width:24px;height:24px;border-radius:50%;background:#eef0f3;color:var(--tert);font-weight:700;display:flex;align-items:center;justify-content:center;margin:0 auto 5px;font-size:12px;}
+    .stp.act .dot{background:var(--brand);color:#fff;}
+    .stp.done .dot{background:var(--ok);color:#fff;}
+    .card{background:#fff;border:1px solid var(--line);border-radius:16px;margin:16px 18px;padding:16px;}
+    .sectit{font-size:13px;font-weight:700;color:var(--brand-d);margin-bottom:11px;}
+    .chip{display:inline-block;font-size:12px;background:var(--brand-l);border:1px solid #ffe1b8;color:#9a5b00;border-radius:99px;padding:5px 11px;margin:0 5px 6px 0;}
+    .btn-main{display:block;width:100%;text-align:center;background:var(--brand);color:#fff;border:none;border-radius:12px;padding:14px;font-family:inherit;font-size:15px;font-weight:700;cursor:pointer;}
+    .btn-main:disabled{background:#f0c89a;cursor:not-allowed;}
+    .gen-note{font-size:12px;color:var(--tert);text-align:center;margin-top:9px;line-height:1.5;}
+    .gen-themes{display:flex;flex-wrap:wrap;gap:7px;}
+    .theme{font-family:inherit;font-size:12px;font-weight:600;color:var(--sub);background:#fff;border:1px solid var(--line);border-radius:99px;padding:7px 13px;cursor:pointer;}
+    .theme.on{background:#f5f3ff;border-color:#c4b5fd;color:#6d28d9;}
+    .gen-lb{display:block;font-size:12px;font-weight:700;color:var(--sub);margin:12px 0 5px;}
+    .gen-opt{font-weight:500;color:var(--tert);}
+    .gen-input{width:100%;border:1px solid var(--line);border-radius:10px;padding:11px;font-family:inherit;font-size:13px;outline:none;}
+    .gen-input:focus{border-color:var(--brand);box-shadow:0 0 0 3px rgba(252,150,0,.13);}
+    .gen-ta{width:100%;min-height:74px;border:1px solid var(--line);border-radius:10px;padding:11px;font-family:inherit;font-size:13px;line-height:1.5;resize:vertical;outline:none;}
+    .gen-ta:focus{border-color:var(--brand);box-shadow:0 0 0 3px rgba(252,150,0,.13);}
+    .photo-row{display:flex;flex-wrap:wrap;gap:8px;}
+    .photo-row:not(:empty){margin-bottom:8px;}
+    .ph{position:relative;width:64px;height:64px;border-radius:9px;overflow:hidden;border:1px solid var(--line);}
+    .ph img{width:100%;height:100%;object-fit:cover;display:block;}
+    .ph button{position:absolute;top:2px;right:2px;width:18px;height:18px;border:none;border-radius:50%;background:rgba(0,0,0,.55);color:#fff;font-size:10px;cursor:pointer;line-height:1;padding:0;}
+    .photo-btn{display:inline-block;font-family:inherit;font-size:13px;font-weight:700;color:var(--brand-d);background:#fff8f0;border:1px dashed #ffc98a;border-radius:9px;padding:9px 14px;cursor:pointer;}
+    .regen{display:block;margin:12px auto 0;font-family:inherit;font-size:12px;font-weight:700;color:#7c3aed;background:#f5f3ff;border:1px solid #ddd6fe;border-radius:9px;padding:8px 14px;cursor:pointer;}
+    .opt{border:1px solid var(--line);border-radius:13px;padding:14px;margin-bottom:8px;}
+    .opt-h{display:flex;align-items:flex-start;gap:11px;margin-bottom:10px;}
+    .opt-ic{width:38px;height:38px;border-radius:10px;background:var(--brand-l);display:flex;align-items:center;justify-content:center;font-size:19px;flex-shrink:0;}
+    .opt-t{font-size:15px;font-weight:700;}
+    .opt-d{font-size:12px;color:var(--sub);line-height:1.45;margin-top:2px;}
+    .opt-soon{font-size:12px;color:var(--tert);background:var(--bg);border-radius:8px;padding:11px;text-align:center;}
+    .gen-or{text-align:center;font-size:12px;color:var(--tert);margin:2px 0 10px;}
+    .type-badge{display:inline-block;font-size:11px;font-weight:700;color:#0a7d4d;background:#eafaf1;border:1px solid #b6ebcf;border-radius:99px;padding:3px 9px;}
+    .sb-head{display:flex;align-items:center;justify-content:space-between;gap:8px;}
+    .sb-theme{font-size:11px;font-weight:700;color:#7c3aed;background:#f5f3ff;border:1px solid #ddd6fe;border-radius:99px;padding:3px 10px;}
+    .sb-total{font-size:12px;color:var(--sub);}
+    .sb-title{font-size:16px;font-weight:800;margin:8px 0 4px;}
+    .sb-prog{display:flex;align-items:center;gap:10px;margin:12px 0 4px;}
+    .sb-bar{flex:1;height:9px;background:#eef0f3;border-radius:99px;overflow:hidden;}
+    .sb-bar i{display:block;height:100%;background:linear-gradient(90deg,#fc9600,#e08600);border-radius:99px;transition:width .3s;}
+    .sb-prog b{font-size:13px;color:var(--brand-d);}
+    .shot{background:#fff;border:1px solid var(--line);border-radius:13px;padding:13px;margin:0 18px 9px;}
+    .shot.done{border-color:#c8efd9;background:#fcfffd;}
+    .shot-t{display:flex;align-items:center;gap:9px;margin-bottom:8px;}
+    .shot-n{width:24px;height:24px;border-radius:8px;background:var(--brand);color:#fff;font-size:12px;font-weight:700;display:flex;align-items:center;justify-content:center;flex-shrink:0;}
+    .shot.done .shot-n{background:var(--ok);}
+    .shot-dur{font-size:11px;color:var(--tert);font-weight:600;background:var(--bg);border-radius:6px;padding:2px 7px;}
+    .shot-stat{margin-left:auto;font-size:11px;font-weight:700;padding:3px 9px;border-radius:99px;}
+    .shot-stat.no{background:#fff3e0;color:#d9740a;}.shot-stat.ok{background:var(--okl);color:#00a35c;}
+    .shot-scene{font-size:14px;font-weight:600;margin-bottom:5px;}
+    .shot-cap{font-size:13px;color:var(--sub);background:var(--bg);border-radius:8px;padding:8px 10px;line-height:1.4;}
+    .shot-cap b{color:var(--brand-d);font-weight:700;font-size:11px;display:block;margin-bottom:2px;}
+    .shot-up{margin-top:9px;}
+    .shot-upbtn{display:block;text-align:center;font-size:12px;font-weight:700;border:1px dashed #ffd49c;background:#fffaf3;color:var(--brand-d);border-radius:9px;padding:10px;cursor:pointer;}
+    .shot-file{display:flex;align-items:center;gap:8px;margin-top:8px;background:var(--okl);border:1px solid #c8efd9;border-radius:9px;padding:7px 10px;}
+    .shot-file .ic{width:30px;height:30px;border-radius:7px;background-size:cover;background-position:center;background:linear-gradient(135deg,#fc9600,#e08600);color:#fff;display:flex;align-items:center;justify-content:center;font-size:15px;text-decoration:none;flex-shrink:0;}
+    .shot-file .fn{font-size:12px;font-weight:600;flex:1;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:var(--ink);text-decoration:none;}
+    .shot-file .fx{font-size:11px;color:var(--tert);background:none;border:none;cursor:pointer;}
+    .shot-prog{font-size:11px;color:var(--brand-d);text-align:center;margin-top:6px;min-height:14px;font-weight:600;}
+    .final-drop{border:2px dashed #ffd49c;border-radius:13px;background:#fffaf3;padding:22px 14px;text-align:center;cursor:pointer;}
+    .final-drop .ic{font-size:30px;line-height:1;}
+    .final-drop .t{font-weight:700;font-size:14px;margin:7px 0 3px;}
+    .final-drop .s{font-size:12px;color:var(--tert);}
+    .cap-typetabs{display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin-bottom:10px;}
+    .ctab{font-family:inherit;font-size:12px;font-weight:700;color:var(--sub);background:#fff;border:1px solid var(--line);border-radius:8px;padding:6px 11px;cursor:pointer;}
+    .ctab.on{background:var(--brand-l);border-color:var(--brand);color:var(--brand-d);}
+    .ctab-note{font-size:11px;color:var(--tert);margin-left:2px;}
+    .cap-box{background:var(--bg);border:1px solid var(--line);border-radius:11px;padding:13px;font-size:13px;line-height:1.6;white-space:pre-wrap;color:var(--ink);word-break:break-word;}
+    .cap-btns{display:flex;gap:8px;margin-top:10px;}
+    .cap-copy{flex:1;font-family:inherit;font-size:13px;font-weight:700;color:#fff;background:var(--brand);border:none;border-radius:10px;padding:11px;cursor:pointer;}
+    .cap-regen{font-family:inherit;font-size:13px;font-weight:700;color:#7c3aed;background:#f5f3ff;border:1px solid #ddd6fe;border-radius:10px;padding:11px 14px;cursor:pointer;}
+    .trust{font-size:11px;color:var(--tert);text-align:center;padding:14px 10px;line-height:1.5;}
+    .state{text-align:center;padding:70px 20px;color:var(--sub);}
+    .state .ic{font-size:44px;margin-bottom:12px;}
+    .spin{width:26px;height:26px;border:3px solid #ffe1b8;border-top-color:var(--brand);border-radius:50%;margin:16px auto 0;animation:sp .8s linear infinite;}
+    .spin.sm{width:14px;height:14px;border-width:2px;display:inline-block;margin:0 0 -2px 6px;}
+    .cap-gen{font-size:13px;color:var(--brand-d);background:#fff8f0;border:1px solid #ffe1b8;border-radius:9px;padding:12px;text-align:center;font-weight:600;}
+    @keyframes sp{to{transform:rotate(360deg)}}
+  </style>
+</head>
+<body>
+  <div class="wrap" id="root">
+    <div class="state"><div class="ic">⏳</div>불러오는 중…</div>
+  </div>
+
+  <script>
+    const FIREBASE_CONFIG = {
+      apiKey: "AIzaSyAQf_Cu9wMji5QsMBQns5eg6nOD_vmrZMs",
+      authDomain: "moyeora-deal-manager.firebaseapp.com",
+      projectId: "moyeora-deal-manager",
+      storageBucket: "moyeora-deal-manager.firebasestorage.app",
+      messagingSenderId: "527148187832",
+      appId: "1:527148187832:web:dc35b0413a7157db34744d"
+    };
+    if (!firebase.apps.length) firebase.initializeApp(FIREBASE_CONFIG);
+    const db = firebase.firestore();
+    const storage = firebase.storage();
+    const STORAGE_ROOT = '셀러_촬영본';
+    const MANUS_FN_URL = 'https://asia-northeast3-moyeora-deal-manager.cloudfunctions.net/manusGuide';
+    const THEMES = ['엄마 공감형', '문제해결형', '비포&애프터', '신뢰 후기형'];
+    const TYPES = { '공구': '🛒', '협찬': '🤝', '자사몰': '🏬' };
+
+    const root = document.getElementById('root');
+    const guideId = new URLSearchParams(location.search).get('id');
+    let guide = null;
+    let genTheme = '엄마 공감형';
+    let genType = '공구';
+    let decided = false;
+    let page = 'guide';   // guide | upload
+    let genPending = null; // 'reels' | 'caption' | null
+    let _unsub = null;
+
+    const esc = s => { if (s == null) return ''; const d = document.createElement('div'); d.textContent = String(s); return d.innerHTML; };
+    const sbOf = g => (g.storyboard && Array.isArray(g.storyboard.shots)) ? g.storyboard : null;
+    const capOf = g => (g.caption && g.caption.text) ? g.caption : null;
+    const gen = (g, kind) => genPending === kind || (g.aiStatus && g.aiStatus[kind] === 'generating');
+    const shotsOf = g => sbOf(g) ? g.storyboard.shots : [];
+    const upOf = g => Array.isArray(g.uploads) ? g.uploads : [];
+    const finOf = g => Array.isArray(g.finalUploads) ? g.finalUploads : [];
+    const shotUp = (g, o) => upOf(g).filter(u => Number(u.shotOrder) === Number(o));
+    const subDone = g => shotsOf(g).filter(s => shotUp(g, s.order).length > 0).length;
+    const typeOf = g => g.type || '공구';
+
+    function stateMsg(ic, msg) { root.innerHTML = `<div class="state"><div class="ic">${ic}</div>${esc(msg)}</div>`; }
+    async function patch(obj) { obj.updatedAt = firebase.firestore.FieldValue.serverTimestamp(); await db.collection('sellerGuides').doc(guideId).update(obj); }
+
+    async function boot() {
+      if (!guideId) { stateMsg('⚠️', '잘못된 링크입니다. 담당 매니저에게 문의해주세요.'); return; }
+      try { await firebase.auth().signInAnonymously(); } catch (e) { console.warn('익명 로그인 실패', e); }
+      try {
+        const doc = await db.collection('sellerGuides').doc(guideId).get();
+        if (!doc.exists) { stateMsg('🔍', '가이드를 찾을 수 없습니다. 링크를 다시 확인해주세요.'); return; }
+        guide = { id: doc.id, ...doc.data() };
+        genType = typeOf(guide);
+        decided = !!(sbOf(guide) && upOf(guide).length);
+        // 새로고침 중에도 생성 진행 상태면 실시간으로 이어받기
+        if (guide.aiStatus && guide.aiStatus.reels === 'generating' && !sbOf(guide)) {
+          genPending = 'reels';
+          watchUntil(g => sbOf(g) || (g.aiStatus && g.aiStatus.reels === 'failed'), g => { genPending = null; if (sbOf(g)) { decided = true; page = 'guide'; } render(); });
+        } else if (guide.aiStatus && guide.aiStatus.caption === 'generating' && !capOf(guide)) {
+          genPending = 'caption';
+          watchUntil(g => capOf(g) || (g.aiStatus && g.aiStatus.caption === 'failed'), g => { genPending = null; render(); });
+        }
+        render();
+      } catch (e) { stateMsg('⚠️', '불러오기 실패: ' + (e.message || e)); }
+    }
+
+    function fileThumb(u) {
+      const isImg = (u.type || '').startsWith('image/') || /\.(jpe?g|png|gif|webp|heic)$/i.test(u.name || '');
+      const isVid = (u.type || '').startsWith('video/') || /\.(mp4|mov|avi|webm|mkv)$/i.test(u.name || '');
+      if (isImg) return `<a class="ic" style="background-image:url('${u.url}')" href="${u.url}" target="_blank" rel="noopener"></a>`;
+      return `<a class="ic" href="${u.url}" target="_blank" rel="noopener">${isVid ? '🎞️' : '📄'}</a>`;
+    }
+
+    function render() {
+      const g = guide, sb = sbOf(g), aps = Array.isArray(g.appealPoints) ? g.appealPoints : [];
+      const total = sb ? sb.shots.length : 0, done = subDone(g), pct = total ? Math.round(done / total * 100) : 0;
+      const ready = sb && decided;
+
+      let h = `
+        <div class="hero">
+          <div class="hi">${ready ? '촬영 가이드가 준비됐어요 ✨' : '안녕하세요 👋'}</div>
+          <div class="nm">${esc(g.sellerName || '셀러')}님</div>
+          <div class="prod">📦 ${esc(g.productName || '상품')} · ${esc(g.categoryName || g.category || '')}</div>
+        </div>
+        <div class="steps">
+          <div class="stp ${ready ? 'done' : 'act'}"><div class="dot">${ready ? '✓' : '1'}</div>가이드 받기</div>
+          <div class="stp ${ready ? (page === 'upload' ? 'done' : 'act') : ''}" ${ready ? `onclick="goPage('guide')" style="cursor:pointer"` : ''}><div class="dot">2</div>촬영, 캡션</div>
+          <div class="stp ${(ready && page === 'upload') ? (done === total ? 'done' : 'act') : ''}" ${ready ? `onclick="goPage('upload')" style="cursor:pointer"` : ''}><div class="dot">3</div>업로드</div>
+        </div>`;
+
+      if (gen(guide, 'reels') && !sb) {
+        h += `<div class="card" style="text-align:center;padding:34px 18px">
+          <div style="font-size:38px">🤖</div>
+          <div style="font-size:15px;font-weight:800;margin:10px 0 6px">AI가 분석·생성 중이에요</div>
+          <div style="font-size:13px;color:var(--sub);line-height:1.6">상품 ${guide.productUrl ? '링크를 열어 ' : ''}정보를 분석해서 릴스 구성안을 만들고 있어요.<br>수십 초~몇 분 걸려요. 이 화면을 켜두면 완료 시 자동으로 표시됩니다.</div>
+          <div class="spin"></div></div>`;
+        root.innerHTML = h; return;
+      }
+
+      if (!sb || !decided) {
+        h += `
+          <div class="card">
+            <div class="sectit">🎬 촬영 가이드 시작하기</div>
+            <div style="font-size:13px;color:var(--sub);line-height:1.55;margin-bottom:14px">두 가지 중 하나를 선택하세요.</div>
+            <div class="opt">
+              <div class="opt-h"><span class="opt-ic">📋</span><div><div class="opt-t">모여라딜이 준비한 구성안 받기</div><div class="opt-d">담당 매니저가 만든 릴스 구성안을 그대로 받아 촬영해요</div></div></div>
+              ${sb
+                ? `<button class="btn-main" style="margin-top:4px" onclick="accept()">✅ 준비된 구성안 받기 (${sb.shots.length}컷)</button>`
+                : (aps.length
+                    ? `<div style="margin:4px 0 0">${aps.map(a => `<span class="chip">${esc(a)}</span>`).join('')}</div><button class="btn-main" id="genBtnPreset" style="margin-top:12px" onclick="genGuide('preset')">✨ 이 포인트로 구성안 받기</button>`
+                    : `<div class="opt-soon">담당 매니저가 구성안을 준비 중이에요</div>`)}
+            </div>
+            <div class="gen-or">또는</div>
+            <div class="opt">
+              <div class="opt-h"><span class="opt-ic">✍️</span><div><div class="opt-t">내가 직접 만들기</div><div class="opt-d">상품 정보·원하는 느낌을 입력하면 AI가 바로 만들어요</div></div></div>
+              <label class="gen-lb">유형 <span class="gen-opt">협찬은 #광고 자동 표기</span></label>
+              <div class="gen-themes" id="genTypes">
+                <button type="button" class="theme ${genType === '공구' ? 'on' : ''}" data-t="공구" onclick="pickGenType('공구')">🛒 공구</button>
+                <button type="button" class="theme ${genType === '협찬' ? 'on' : ''}" data-t="협찬" onclick="pickGenType('협찬')">🤝 협찬</button>
+              </div>
+              <label class="gen-lb">상품명</label>
+              <input id="sellerProduct" class="gen-input" placeholder="예: 욕실 미끄럼방지 코팅제" value="${esc(g.productName || '')}">
+              <label class="gen-lb">상품 링크 <span class="gen-opt">(선택)</span></label>
+              <input id="sellerUrl" class="gen-input" type="url" placeholder="스마트스토어·홈페이지 등 상품 페이지 주소" value="${esc(g.productUrl || '')}">
+              <label class="gen-lb">상품 사진 <span class="gen-opt">(선택)</span></label>
+              <div class="photo-row" id="sellerPhotos">${(g.photos || []).map(p => `<div class="ph"><img src="${p.url}"><button type="button" onclick="delPhoto('${esc(p.path)}')">✕</button></div>`).join('')}</div>
+              <label class="photo-btn">📷 상품 사진 올리기<input type="file" accept="image/*" multiple style="display:none" onchange="pickPhoto(this)"></label>
+              <label class="gen-lb">원하는 톤</label>
+              <div class="gen-themes" id="genThemes">${THEMES.map(t => `<button type="button" class="theme ${t === genTheme ? 'on' : ''}" data-t="${esc(t)}" onclick="pickTheme('${esc(t)}')">${esc(t)}</button>`).join('')}</div>
+              <label class="gen-lb">상품 특징·원하는 느낌</label>
+              <textarea id="sellerInput" class="gen-ta" placeholder="예) 아이 안전을 강조, 바르기 쉬운 점 부각, 비포&애프터로 빠르게"></textarea>
+              <button class="btn-main" id="genBtnCustom" style="margin-top:12px" onclick="genGuide('custom')">✨ 내 입력으로 구성안 만들기</button>
+            </div>
+            <div class="gen-note">과장 없이, 솔직하게. 모여라딜이 함께 만듭니다.</div>
+          </div>`;
+        root.innerHTML = h; return;
+      }
+
+      if (page !== 'upload') {
+        h += `
+          <div class="card">
+            <div class="sb-head"><span><span class="type-badge">${TYPES[typeOf(g)] || ''} ${esc(typeOf(g))}</span> <span class="sb-theme">🎭 ${esc(sb.theme || '')}</span></span><span class="sb-total">${total}컷 · ${esc(sb.totalDuration || '')}</span></div>
+            <div class="sb-title">${esc(sb.title || '최종 릴스 구성안')}</div>
+            <div style="font-size:12px;color:var(--tert);margin-top:5px">아래 컷 순서대로 촬영하고 캡션을 준비한 뒤, 업로드로 넘어가세요.</div>
+            ${done === 0 ? `<button class="regen" onclick="regen()">🔄 구성안 다시 만들기</button>` : ''}
+          </div>`;
+        shotsOf(g).forEach(s => {
+          const ok = shotUp(g, s.order).length > 0;
+          h += `
+            <div class="shot ${ok ? 'done' : ''}">
+              <div class="shot-t"><span class="shot-n">${s.order}</span><span class="shot-dur">${esc(s.duration || '')}</span><span class="shot-stat ${ok ? 'ok' : 'no'}">${ok ? '✓ 업로드됨' : '🎬 촬영'}</span></div>
+              <div class="shot-scene">${esc(s.scene || '')}</div>
+              <div class="shot-cap"><b>자막</b>"${esc(s.subtitle || '')}"</div>
+            </div>`;
+        });
+        const cap = g.caption;
+        h += `
+          <div class="card">
+            <div class="sectit">📝 인스타그램 캡션 <span style="font-weight:500;color:var(--tert)">· 게시할 때</span></div>
+            ${gen(g, 'caption') ? `<div class="cap-gen">🤖 AI가 캡션을 만들고 있어요…<span class="spin sm"></span></div>` : (cap && cap.text ? `
+              <div class="cap-typetabs">
+                <button class="ctab ${typeOf(g) === '공구' ? 'on' : ''}" onclick="setType('공구')">🛒 공구</button>
+                <button class="ctab ${typeOf(g) === '협찬' ? 'on' : ''}" onclick="setType('협찬')">🤝 협찬</button>
+                <span class="ctab-note">유형 바꾸면 캡션·해시태그가 바뀌어요</span>
+              </div>
+              <div class="cap-box">${esc(cap.text)}${(cap.hashtags && cap.hashtags.length) ? '\n\n' + cap.hashtags.map(esc).join(' ') : ''}</div>
+              <div class="cap-btns"><button class="cap-copy" onclick="copyCaption()">📋 복사</button><button class="cap-regen" onclick="genCaption()">🔄 다시 생성</button></div>`
+              : `<div style="font-size:13px;color:var(--sub);line-height:1.55;margin-bottom:11px">게시물에 바로 붙여넣을 캡션 + 해시태그를 자동으로 만들어드려요. <b>(${TYPES[typeOf(g)] || ''} ${esc(typeOf(g))} 유형)</b></div>
+                 <button class="btn-main" id="capBtn" onclick="genCaption()">✨ 인스타 캡션 자동 생성</button>`)}
+          </div>`;
+        h += `<div style="padding:2px 18px 0"><button class="btn-main" onclick="goPage('upload')">📤 촬영본 업로드하러 가기 →</button></div>`;
+        h += `<div class="trust">촬영·캡션을 준비했으면 업로드로 넘어가세요</div>`;
+      } else {
+        h += `
+          <div class="card">
+            <div class="sb-head"><span><span class="type-badge">${TYPES[typeOf(g)] || ''} ${esc(typeOf(g))}</span> <span class="sb-theme">📤 촬영본 업로드</span></span><span class="sb-total">${total}컷</span></div>
+            <div class="sb-prog"><div class="sb-bar"><i style="width:${pct}%"></i></div><b>${done}/${total}</b></div>
+            <div style="font-size:12px;color:var(--tert)">${done === total ? '모든 컷 제출 완료! 🎉' : (done ? '잘하고 있어요 — 남은 컷도 올려주세요' : '컷마다 영상을 올려주세요')}</div>
+          </div>`;
+        shotsOf(g).forEach(s => {
+          const ups = shotUp(g, s.order), ok = ups.length > 0;
+          h += `
+            <div class="shot ${ok ? 'done' : ''}">
+              <div class="shot-t"><span class="shot-n">${s.order}</span><span class="shot-dur">${esc(s.duration || '')}</span><span class="shot-stat ${ok ? 'ok' : 'no'}">${ok ? '✓ 제출됨' : '⏳ 미제출'}</span></div>
+              <div class="shot-scene">${esc(s.scene || '')}</div>
+              <div class="shot-cap"><b>자막</b>"${esc(s.subtitle || '')}"</div>
+              ${ups.map(u => `<div class="shot-file">${fileThumb(u)}<a class="fn" href="${u.url}" target="_blank" rel="noopener">${esc(u.name)}</a><button class="fx" onclick="delUp('${esc(u.path)}')">삭제</button></div>`).join('')}
+              <div class="shot-up"><label class="shot-upbtn">📎 ${ok ? '영상 더 올리기' : '이 컷 촬영본 올리기'}<input type="file" multiple accept="image/*,video/*" style="display:none" onchange="pickShot(${s.order},this)"></label></div>
+              <div class="shot-prog" id="prog${s.order}"></div>
+            </div>`;
+        });
+        const fu = finOf(g);
+        h += `
+          <div class="card">
+            <div class="sectit">🎬 최종본 올리기 <span style="font-weight:500;color:var(--tert)">· 편집 완료 영상</span></div>
+            <div class="final-drop" onclick="document.getElementById('finalInput').click()"><div class="ic">🎬</div><div class="t">편집 완료한 릴스(최종 영상) 올리기</div><div class="s">완성된 영상 파일을 올려주세요</div><input type="file" id="finalInput" multiple accept="video/*,image/*" style="display:none" onchange="pickFinal(this)"></div>
+            <div class="shot-prog" id="finalProg"></div>
+            ${fu.map(u => `<div class="shot-file">${fileThumb(u)}<a class="fn" href="${u.url}" target="_blank" rel="noopener">${esc(u.name)}</a><button class="fx" onclick="delFinal('${esc(u.path)}')">삭제</button></div>`).join('')}
+          </div>`;
+        h += `<div class="trust">올린 영상은 담당 매니저에게 전달됩니다</div>`;
+      }
+      root.innerHTML = h;
+    }
+
+    /* ── 선택/이동 ── */
+    function pickTheme(t) { genTheme = t; document.querySelectorAll('#genThemes .theme').forEach(b => b.classList.toggle('on', b.dataset.t === t)); }
+    function pickGenType(t) { genType = t; document.querySelectorAll('#genTypes .theme').forEach(b => b.classList.toggle('on', b.dataset.t === t)); }
+    function accept() { decided = true; page = 'guide'; render(); }
+    function goPage(p) { page = p; render(); }
+    async function regen() { if (!confirm('현재 구성안을 지우고 다시 선택할까요?')) return; await patch({ storyboard: null }); guide.storyboard = null; decided = false; render(); }
+
+    /* ── Manus 요청 / 실시간 대기 ── */
+    function watchUntil(predicate, onDone) {
+      if (_unsub) { _unsub(); _unsub = null; }
+      _unsub = db.collection('sellerGuides').doc(guideId).onSnapshot(doc => {
+        if (!doc.exists) return; guide = { id: doc.id, ...doc.data() };
+        if (predicate(guide)) { if (_unsub) { _unsub(); _unsub = null; } onDone(guide); }
+      });
+    }
+    async function requestManus(kind, extra) {
+      const payload = Object.assign({
+        guideId, kind, type: typeOf(guide),
+        sellerName: guide.sellerName || '', productName: guide.productName || '',
+        category: guide.categoryName || guide.category || '',
+        appealPoints: guide.appealPoints || [], productUrl: guide.productUrl || '',
+        photos: guide.photos || [], theme: genTheme,
+      }, extra || {});
+      const resp = await fetch(MANUS_FN_URL, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+      if (!resp.ok) { const e = await resp.json().catch(() => ({})); throw new Error(e.error || ('서버 ' + resp.status)); }
+      return resp.json();
+    }
+
+    /* ── 구성안 생성 (Manus) ── */
+    async function genGuide(mode) {
+      const sellerInput = mode === 'custom' ? (document.getElementById('sellerInput')?.value.trim() || '') : '';
+      const sellerProduct = mode === 'custom' ? (document.getElementById('sellerProduct')?.value.trim() || '') : '';
+      const sellerUrl = mode === 'custom' ? (document.getElementById('sellerUrl')?.value.trim() || '') : '';
+      if (mode === 'custom' && !sellerInput && !sellerProduct) { alert('상품명이나 원하는 느낌을 입력해주세요.'); return; }
+      const pre = {};
+      if (mode === 'custom') { guide.type = genType; pre.type = genType; if (sellerProduct) pre.productName = sellerProduct; if (sellerUrl) pre.productUrl = sellerUrl; }
+      try {
+        if (Object.keys(pre).length) { await patch(pre); Object.assign(guide, pre); }
+        genPending = 'reels'; render();
+        await requestManus('reels', { appealPoints: mode === 'preset' ? (guide.appealPoints || []) : [], sellerInput });
+        watchUntil(g => sbOf(g) || (g.aiStatus && g.aiStatus.reels === 'failed'), g => {
+          if (sbOf(g)) { genPending = null; decided = true; page = 'guide'; render(); }
+          else { genPending = null; render(); alert('생성에 실패했습니다. 잠시 후 다시 시도하거나 매니저에게 문의해주세요.'); }
+        });
+      } catch (e) { genPending = null; render(); alert('생성 요청 실패: ' + (e.message || e)); }
+    }
+
+    /* ── 캡션 (Manus) ── */
+    async function setType(t) {
+      guide.type = t;
+      try { await patch({ type: t }); } catch (e) {}
+      if (capOf(guide)) await genCaption(); else render();
+    }
+    async function genCaption() {
+      try {
+        genPending = 'caption'; render();
+        await requestManus('caption', { storyboard: sbOf(guide) || null });
+        watchUntil(g => capOf(g) || (g.aiStatus && g.aiStatus.caption === 'failed'), g => {
+          genPending = null; render();
+          if (!capOf(g)) alert('캡션 생성에 실패했습니다. 잠시 후 다시 시도해주세요.');
+        });
+      } catch (e) { genPending = null; render(); alert('캡션 요청 실패: ' + (e.message || e)); }
+    }
+    function copyCaption() {
+      const c = guide.caption; if (!c) return;
+      const txt = (c.text || '') + ((c.hashtags && c.hashtags.length) ? '\n\n' + c.hashtags.join(' ') : '');
+      if (navigator.clipboard?.writeText) navigator.clipboard.writeText(txt).then(() => alert('캡션이 복사되었습니다 📋')).catch(() => prompt('복사하세요', txt));
+      else prompt('복사하세요', txt);
+    }
+
+    /* ── 업로드 ── */
+    async function uploadTo(folder, files, by, shotOrder) {
+      const added = [];
+      for (const file of files) {
+        const safe = file.name.replace(/[^\w.\-가-힣]/g, '_');
+        const path = `${STORAGE_ROOT}/${guideId}/${folder}/${Date.now()}_${safe}`;
+        const ref = storage.ref().child(path);
+        await ref.put(file, { contentType: file.type || 'application/octet-stream' });
+        const url = await ref.getDownloadURL();
+        const item = { name: file.name, path, url, size: file.size, type: file.type || '', uploadedAt: new Date().toISOString(), by };
+        if (shotOrder != null) item.shotOrder = Number(shotOrder);
+        added.push(item);
+      }
+      return added;
+    }
+    async function pickShot(order, input) {
+      const files = Array.from(input.files || []); input.value = '';
+      if (!files.length) return;
+      const prog = document.getElementById('prog' + order);
+      try {
+        if (prog) prog.textContent = '업로드 중…';
+        const added = await uploadTo('cut' + order, files, 'seller', order);
+        const uploads = upOf(guide).concat(added);
+        await patch({ uploads }); guide.uploads = uploads; render();
+      } catch (e) { if (prog) prog.textContent = '업로드 실패: ' + (e.message || e); }
+    }
+    async function delUp(path) {
+      if (!confirm('이 영상을 삭제할까요?')) return;
+      try { await storage.ref().child(path).delete().catch(() => {}); const uploads = upOf(guide).filter(u => u.path !== path); await patch({ uploads }); guide.uploads = uploads; render(); }
+      catch (e) { alert('삭제 실패: ' + (e.message || e)); }
+    }
+    async function pickFinal(input) {
+      const files = Array.from(input.files || []); input.value = '';
+      if (!files.length) return;
+      const prog = document.getElementById('finalProg');
+      try {
+        if (prog) prog.textContent = '업로드 중…';
+        const added = await uploadTo('최종본', files, 'seller');
+        const finalUploads = finOf(guide).concat(added);
+        await patch({ finalUploads }); guide.finalUploads = finalUploads; render();
+      } catch (e) { if (prog) prog.textContent = '업로드 실패: ' + (e.message || e); }
+    }
+    async function delFinal(path) {
+      if (!confirm('이 최종본을 삭제할까요?')) return;
+      try { await storage.ref().child(path).delete().catch(() => {}); const finalUploads = finOf(guide).filter(u => u.path !== path); await patch({ finalUploads }); guide.finalUploads = finalUploads; render(); }
+      catch (e) { alert('삭제 실패: ' + (e.message || e)); }
+    }
+
+    /* ── 상품 사진 (decision 폼) ── */
+    async function pickPhoto(input) {
+      const files = Array.from(input.files || []).filter(f => f.type.startsWith('image/')); input.value = '';
+      if (!files.length) return;
+      const el = document.getElementById('sellerPhotos');
+      try {
+        const added = await uploadTo('상품사진', files, 'seller');
+        const photos = (guide.photos || []).concat(added.map(a => ({ name: a.name, path: a.path, url: a.url })));
+        await patch({ photos }); guide.photos = photos;
+        if (el) el.innerHTML = photos.map(p => `<div class="ph"><img src="${p.url}"><button type="button" onclick="delPhoto('${esc(p.path)}')">✕</button></div>`).join('');
+      } catch (e) { alert('사진 업로드 실패: ' + (e.message || e)); }
+    }
+    async function delPhoto(path) {
+      try { await storage.ref().child(path).delete().catch(() => {}); const photos = (guide.photos || []).filter(p => p.path !== path); await patch({ photos }); guide.photos = photos;
+        const el = document.getElementById('sellerPhotos'); if (el) el.innerHTML = photos.map(p => `<div class="ph"><img src="${p.url}"><button type="button" onclick="delPhoto('${esc(p.path)}')">✕</button></div>`).join('');
+      } catch (e) {}
+    }
+
+    boot();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
셀러용 릴스 촬영 가이드 페이지를 `supplier/guide/index.html` 경로에 새로 추가합니다.

- Firebase(Firestore/Storage) 연동 기반 셀러 촬영 가이드 화면
- 구성안 받기 / 직접 만들기, 촬영본·최종본 업로드, 인스타 캡션 생성 흐름 포함

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNXzvmSQQYndmGa7Sm1d5N)_