### PR TITLE
Let sellers start a new product guide from the portal

### DIFF
--- a/supplier/guide/index.html
+++ b/supplier/guide/index.html
@@ -217,7 +217,8 @@
             </div>
           </div>`;
       });
-      h += `<div class="trust">제품을 선택하면 촬영 가이드·캡션·업로드 화면으로 이동해요</div>`;
+      h += `<div style="padding:4px 18px 0"><button class="btn-main" onclick="createNewProduct()" style="background:#fff;color:var(--brand-d);border:1.5px dashed #ffc98a">+ 새 제품 가이드 만들기</button></div>`;
+      h += `<div class="trust">제품을 선택하면 촬영 가이드·캡션·업로드 화면으로 이동해요.<br>새 제품을 직접 시작하려면 위 버튼을 누르세요.</div>`;
       root.innerHTML = h;
     }
     async function openGuide(id) {
@@ -241,6 +242,15 @@
       mode = 'portal'; fromPortal = false; guide = null; guideId = null;
       window.scrollTo({ top: 0 });
       loadPortal();
+    }
+    // 셀러가 직접 새 제품(가이드) 시작
+    async function createNewProduct() {
+      const name = (portalGuides[0] && portalGuides[0].sellerName) || '';
+      try {
+        const ref = db.collection('sellerGuides').doc();
+        await ref.set({ sellerId: sellerKey, sellerName: name, type: '공구', createdBy: 'seller', createdAt: firebase.firestore.FieldValue.serverTimestamp(), updatedAt: firebase.firestore.FieldValue.serverTimestamp() });
+        openGuide(ref.id);
+      } catch (e) { alert('새 제품 만들기 실패: ' + (e.message || e)); }
     }
 
     function fileThumb(u) {


### PR DESCRIPTION
셀러 포털에서 셀러가 직접 새 제품 가이드를 시작할 수 있도록 추가합니다.

- `createNewProduct()` 추가: `sellerGuides` 문서를 셀러가 직접 생성하고 바로 해당 가이드로 이동
- 포털 화면에 "새 제품 가이드 만들기" 버튼 및 안내 문구 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNXzvmSQQYndmGa7Sm1d5N)_