### PR TITLE
feat(custom-proposal): 슬라이드별 인라인 편집모드(WYSIWYG) + 릴스 영상 자동재생

### DIFF
--- a/supplier/custom-proposal/view.html
+++ b/supplier/custom-proposal/view.html
@@ -3965,6 +3965,151 @@
                 text-align: center;
             }
         }
+
+        /* ===== 인라인 편집모드(WYSIWYG) ===== */
+        .edit-toolbar {
+            position: fixed;
+            top: 16px;
+            right: 16px;
+            z-index: 1000;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            background: rgba(18, 18, 31, 0.92);
+            border: 1px solid rgba(249, 115, 22, 0.4);
+            border-radius: 999px;
+            padding: 8px 12px;
+            backdrop-filter: blur(10px);
+            box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+        }
+        .ed-toolbar-group { display: none; align-items: center; gap: 10px; }
+        body.edit-mode .ed-toolbar-group { display: flex; }
+        .ed-btn {
+            font-family: inherit;
+            font-size: 13px;
+            font-weight: 700;
+            color: #fff;
+            background: rgba(255,255,255,0.08);
+            border: 1px solid rgba(255,255,255,0.15);
+            border-radius: 999px;
+            padding: 8px 14px;
+            cursor: pointer;
+            white-space: nowrap;
+            transition: all 0.2s;
+        }
+        .ed-btn:hover { background: rgba(255,255,255,0.16); }
+        .ed-toggle { background: linear-gradient(135deg, var(--accent), #ea8000); border-color: transparent; color: #111; }
+        .ed-save { background: var(--green); border-color: transparent; }
+        .ed-save.dirty { animation: edPulse 1.4s ease-in-out infinite; }
+        @keyframes edPulse { 0%,100% { box-shadow: 0 0 0 0 rgba(16,185,129,0.5);} 50% { box-shadow: 0 0 0 6px rgba(16,185,129,0);} }
+        .ed-deal-label { font-size: 12px; color: var(--text-muted); display: flex; align-items: center; gap: 6px; }
+        .ed-deal-select {
+            font-family: inherit; font-size: 12px; font-weight: 700;
+            background: rgba(255,255,255,0.08); color: #fff;
+            border: 1px solid rgba(255,255,255,0.2); border-radius: 8px; padding: 5px 8px; cursor: pointer;
+        }
+        .ed-deal-select option { color: #111; }
+
+        /* 편집 가능한 텍스트 필드 */
+        body.edit-mode .ed-field {
+            outline: 1px dashed rgba(249, 115, 22, 0.55);
+            outline-offset: 2px;
+            border-radius: 3px;
+            padding: 0 2px;
+            min-width: 24px;
+            cursor: text;
+            transition: background 0.15s, outline-color 0.15s;
+        }
+        body.edit-mode .ed-field:hover { background: rgba(249, 115, 22, 0.08); }
+        body.edit-mode .ed-field:focus { outline: 2px solid var(--accent); background: rgba(249, 115, 22, 0.12); }
+        body.edit-mode .ed-field:empty::before {
+            content: attr(data-ph-text);
+            color: rgba(148, 163, 184, 0.6);
+            font-weight: 400;
+        }
+
+        /* URL 입력칸 (이미지/상세링크) */
+        .ed-only { display: none; }
+        body.edit-mode .ed-only { display: block; }
+        .ed-url, .ed-input {
+            font-family: inherit;
+            font-size: 12px;
+            width: 100%;
+            margin-top: 8px;
+            background: rgba(0,0,0,0.35);
+            color: #fff;
+            border: 1px solid rgba(249, 115, 22, 0.4);
+            border-radius: 8px;
+            padding: 7px 10px;
+            box-sizing: border-box;
+        }
+        .ed-url::placeholder, .ed-input::placeholder { color: rgba(255,255,255,0.4); }
+        .ed-url:focus, .ed-input:focus { outline: none; border-color: var(--accent); }
+        /* 상품 이미지 위 URL 입력칸 위치 */
+        body.edit-mode .product-image-box { position: relative; }
+
+        /* 소구점 추가/삭제 */
+        body.edit-mode .points-list li { position: relative; display: flex; align-items: center; gap: 6px; }
+        .ed-del {
+            flex: none;
+            width: 20px; height: 20px; line-height: 18px;
+            border-radius: 50%;
+            border: 1px solid rgba(239,68,68,0.5);
+            background: rgba(239,68,68,0.15);
+            color: #ef4444; font-weight: 700; cursor: pointer; padding: 0;
+            font-size: 13px;
+        }
+        .ed-del:hover { background: rgba(239,68,68,0.3); }
+        .ed-add {
+            display: inline-block;
+            margin-top: 10px;
+            font-family: inherit; font-size: 12px; font-weight: 700;
+            color: var(--accent);
+            background: rgba(249,115,22,0.1);
+            border: 1px dashed rgba(249,115,22,0.5);
+            border-radius: 8px; padding: 7px 12px; cursor: pointer;
+        }
+        .ed-add:hover { background: rgba(249,115,22,0.2); }
+
+        /* 릴스 편집 패널 (커버 슬라이드) */
+        .ed-reels-panel {
+            max-width: 560px;
+            margin: 24px auto 0;
+            background: rgba(18,18,31,0.85);
+            border: 1px solid rgba(249,115,22,0.35);
+            border-radius: 14px;
+            padding: 16px;
+        }
+        .ed-panel-title { font-size: 13px; font-weight: 800; color: #fff; margin-bottom: 12px; }
+        .ed-panel-title span { display: block; font-size: 11px; font-weight: 400; color: var(--text-muted); margin-top: 3px; }
+        .ed-reels-row { display: flex; gap: 8px; margin-bottom: 8px; align-items: center; }
+        .ed-reels-row .ed-input { margin-top: 0; }
+        .ed-reels-type { flex: 0 0 96px; cursor: pointer; }
+        .ed-reels-url { flex: 1 1 auto; }
+        .ed-reels-label { flex: 0 0 110px; }
+
+        /* 편집모드 안내 토스트 */
+        .ed-toast {
+            position: fixed;
+            bottom: 24px; left: 50%;
+            transform: translateX(-50%) translateY(20px);
+            background: rgba(18,18,31,0.95);
+            color: #fff; font-size: 14px; font-weight: 600;
+            border: 1px solid rgba(16,185,129,0.5);
+            border-radius: 999px; padding: 12px 22px;
+            z-index: 1001; opacity: 0; pointer-events: none;
+            transition: all 0.25s;
+        }
+        .ed-toast.show { opacity: 1; transform: translateX(-50%) translateY(0); }
+        .ed-toast.err { border-color: rgba(239,68,68,0.6); }
+
+        @media (max-width: 480px) {
+            .edit-toolbar { top: 10px; right: 10px; left: 10px; justify-content: center; padding: 7px 10px; gap: 8px; }
+            .ed-btn { font-size: 12px; padding: 7px 11px; }
+            .ed-reels-panel { margin-top: 16px; padding: 12px; }
+            .ed-reels-row { flex-wrap: wrap; }
+            .ed-reels-type, .ed-reels-label { flex: 1 1 100%; }
+        }
     </style>
 </head>
 <body>
@@ -3972,6 +4117,20 @@
     <div class="loading-screen" id="loadingScreen">
         <div class="loading-spinner"></div>
         <p class="loading-text">맞춤 제안서를 불러오는 중...</p>
+    </div>
+
+    <!-- 편집모드 툴바 -->
+    <div class="edit-toolbar" id="editToolbar">
+        <button type="button" class="ed-btn ed-toggle" id="edToggle"><i class="fas fa-pen"></i> 편집모드</button>
+        <div class="ed-only ed-toolbar-group">
+            <label class="ed-deal-label">딜가
+                <select id="edDealStatus" class="ed-deal-select">
+                    <option value="negotiating">협의중</option>
+                    <option value="confirmed">확정</option>
+                </select>
+            </label>
+            <button type="button" class="ed-btn ed-save" id="edSave"><i class="fas fa-save"></i> 저장</button>
+        </div>
     </div>
 
     <!-- 왼쪽 사이드바 (슬라이드 썸네일) -->
@@ -4030,6 +4189,16 @@
         const PH_PRODUCT = makePlaceholder('상품 이미지');
         const PH_NEUTRAL = makePlaceholder('콘텐츠 준비중');
 
+        // 릴스 기본 GIF (reelsMedia 미지정 시 사용 + 편집모드 진입 시 시드)
+        const DEFAULT_REELS = [
+            'https://ecimg.cafe24img.com/pg2246b37345376080/moyeora02/web/upload/wz/gif1.gif',
+            'https://ecimg.cafe24img.com/pg2246b37345376080/moyeora02/web/upload/wz/gif2.gif',
+            'https://ecimg.cafe24img.com/pg2246b37345376080/moyeora02/web/upload/wz/gif3.gif',
+            'https://ecimg.cafe24img.com/pg2246b37345376080/moyeora02/web/upload/wz/gif4.gif',
+            'https://ecimg.cafe24img.com/pg2246b37345376080/moyeora02/web/upload/wz/gif5.gif',
+            'https://ecimg.cafe24img.com/pg2246b37345376080/moyeora02/web/upload/wz/gif6.gif'
+        ];
+
         // 캡처 단계에서 모든 img/video 로드 오류를 가로채 플레이스홀더로 대체
         // (error 이벤트는 버블링되지 않으므로 capture=true 로 window 에서 수신, 동적 추가 이미지도 커버)
         window.addEventListener('error', function (e) {
@@ -4055,6 +4224,49 @@
         let pageStartTimes = {};
         let currentSlideIndex = 0;
         let slides = [];
+
+        // ===== 인라인 편집모드(WYSIWYG) 상태 & 헬퍼 =====
+        let editMode = false;       // 편집모드 on/off (renderSlides 가 이 값에 따라 편집 가능한 마크업을 그림)
+        let editDirty = false;      // 저장 안 된 변경 존재 여부
+        let rerenderTimer = null;
+
+        function escAttr(s) { return String(s == null ? '' : s).replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;'); }
+
+        // path('products.0.name', 'brand.slogan') 로 객체 값 읽기/쓰기
+        function getByPath(obj, path) {
+            return path.split('.').reduce((o, k) => (o == null ? undefined : o[k]), obj);
+        }
+        function setByPath(obj, path, value) {
+            const keys = path.split('.');
+            let o = obj;
+            for (let i = 0; i < keys.length - 1; i++) {
+                const k = keys[i];
+                if (o[k] == null || typeof o[k] !== 'object') o[k] = (/^\d+$/.test(keys[i + 1]) ? [] : {});
+                o = o[k];
+            }
+            o[keys[keys.length - 1]] = value;
+        }
+
+        // 편집 가능한 텍스트 — 편집모드일 때만 contenteditable 스팬으로 감싼다(평상시엔 원본 값 그대로)
+        // opts: { num:true(숫자필드), ph:'플레이스홀더', block:true(여러 줄) }
+        function edt(path, value, opts) {
+            opts = opts || {};
+            const v = (value == null ? '' : String(value));
+            if (!editMode) return v;
+            const attrs = ['class="ed-field"', `data-edit="${escAttr(path)}"`, 'contenteditable="true"', 'spellcheck="false"'];
+            if (opts.num) attrs.push('data-type="number"');
+            if (opts.block) attrs.push('data-block="1"');
+            if (opts.ph) attrs.push(`data-ph-text="${escAttr(opts.ph)}"`);
+            return `<span ${attrs.join(' ')}>${v}</span>`;
+        }
+
+        // 편집 가능한 이미지 — 평상시엔 기존과 동일, 편집모드에선 URL 입력칸을 덧붙인다
+        function edImage(path, url, alt, missingHtml) {
+            const has = !!url;
+            const imgTag = `<img src="${escAttr(url || PH_PRODUCT)}" alt="${escAttr(alt || '')}" data-ph="product">`;
+            if (!editMode) return has ? `<img src="${escAttr(url)}" alt="${escAttr(alt || '')}" data-ph="product">` : (missingHtml || '<div class="product-placeholder">📦</div>');
+            return `${imgTag}<input class="ed-url ed-only" type="text" placeholder="이미지 URL (https://...)" value="${escAttr(url || '')}" data-edit="${escAttr(path)}" data-rerender="1">`;
+        }
 
         // URL에서 ID 가져오기
         function getProposalId() {
@@ -4175,6 +4387,9 @@
                 // 스크롤 추적 설정
                 setupScrollTracking();
 
+                // 편집모드 툴바/이벤트 초기화 (?edit=1 자동 진입 포함)
+                setupEditToolbar();
+
                 // 로딩 숨기기
                 hideLoading();
 
@@ -4273,8 +4488,8 @@
             const today = new Date();
             const dateStr = `${today.getFullYear()}.${String(today.getMonth() + 1).padStart(2, '0')}`;
 
-            // 브랜드 정보 존재 여부
-            const hasBrand = brand.slogan || brand.story;
+            // 브랜드 정보 존재 여부 (편집모드에선 비어 있어도 슬라이드를 띄워 입력 가능하게)
+            const hasBrand = brand.slogan || brand.story || editMode;
 
             // 상품 개수에 따른 슬라이드 번호 계산
             // 슬라이드 1: 커버, 2: 문제점+비용, 3: 솔루션+절감, 4: 브랜드(optional), 5+: 상품
@@ -4323,6 +4538,22 @@
                     // 셀링포인트 최대 3개만 표시
                     const displaySellingPoints = uniqueSellingPoints.slice(0, 3);
 
+                    // 편집 가능한 전략/KPI/소구점 — 저장된 값(proposalData.strategy/kpi/appealPoints)이 있으면 우선, 없으면 자동 생성값
+                    const S = proposalData.strategy || {};
+                    const K = proposalData.kpi || {};
+                    const has = (x) => x != null && x !== '';
+                    const vTarget = has(S.target) ? S.target : targetAudience;
+                    const vSeller = has(S.seller) ? S.seller : targetSeller;
+                    const vChannel = has(S.channel) ? S.channel : pStrategy.salesChannel;
+                    const vContent = has(S.content) ? S.content : contentType;
+                    const vPromo = has(S.promo) ? S.promo : pStrategy.promoStrategy;
+                    const vSales = has(K.sales) ? K.sales : (hasAnalysis ? analysis.expectedSales : pStrategy.salesEstimate);
+                    const vContents = has(K.contents) ? K.contents : (hasAnalysis ? analysis.expectedContent : pStrategy.contentCount);
+                    const vSettle = has(K.settle) ? K.settle : pStrategy.settlementDays;
+                    // 소구점: 저장된 appealPoints 우선, 없으면 기존(상품별 셀링포인트) 유지
+                    const appealList = (Array.isArray(proposalData.appealPoints) && proposalData.appealPoints.length)
+                        ? proposalData.appealPoints : displaySellingPoints;
+
                     productSlides += `
                         <!-- 슬라이드 ${currentSlide}: 상품 ${idx + 1} -->
                         <section id="slide-${currentSlide}" class="slide slide-product-single" data-slide="${currentSlide}" data-product-index="${idx}">
@@ -4331,17 +4562,19 @@
                                 <div class="product-top-bar">
                                     <div class="product-top-left">
                                         <span class="product-index-badge">${idx === 0 ? '대표 상품' : `상품 ${idx + 1}`}</span>
-                                        <h2 class="product-name-title">${product.name}</h2>
+                                        <h2 class="product-name-title">${edt(`products.${idx}.name`, product.name, { ph: '상품명' })}</h2>
                                     </div>
                                     <div class="product-top-right">
                                         <div class="product-price-info">
-                                            ${product.originalPrice ? `<span class="price-original">${formatPrice(product.originalPrice)}원</span>` : ''}
-                                            ${product.dealPrice && proposalData.dealPriceStatus === 'confirmed' ? `
-                                                <span class="price-deal">${formatPrice(product.dealPrice)}원</span>
-                                                ${product.discount ? `<span class="price-discount">${product.discount}%</span>` : ''}
+                                            ${(product.originalPrice || editMode) ? `<span class="price-original">${edt(`products.${idx}.originalPrice`, product.originalPrice ? formatPrice(product.originalPrice) : '', { num: true, ph: '정가' })}원</span>` : ''}
+                                            ${((product.dealPrice && proposalData.dealPriceStatus === 'confirmed') || editMode) ? `
+                                                <span class="price-deal">${edt(`products.${idx}.dealPrice`, product.dealPrice ? formatPrice(product.dealPrice) : '', { num: true, ph: '딜가' })}원</span>
+                                                ${(product.discount || editMode) ? `<span class="price-discount">${edt(`products.${idx}.discount`, product.discount || '', { num: true, ph: '%' })}%</span>` : ''}
                                             ` : ''}
                                         </div>
-                                        ${product.detailUrl ? `<a href="${product.detailUrl}" target="_blank" class="detail-link-btn"><i class="fas fa-external-link-alt"></i> 상품 보기</a>` : ''}
+                                        ${editMode
+                                            ? `<input class="ed-url ed-only" type="text" placeholder="상품 상세 URL (https://...)" value="${escAttr(product.detailUrl || '')}" data-edit="products.${idx}.detailUrl">`
+                                            : (product.detailUrl ? `<a href="${product.detailUrl}" target="_blank" class="detail-link-btn"><i class="fas fa-external-link-alt"></i> 상품 보기</a>` : '')}
                                     </div>
                                 </div>
 
@@ -4350,7 +4583,7 @@
                                     <!-- 왼쪽: 상품 이미지 -->
                                     <div class="product-image-col">
                                         <div class="product-image-box">
-                                            ${product.image ? `<img src="${product.image}" alt="${product.name}" data-ph="product">` : '<div class="product-placeholder">📦</div>'}
+                                            ${edImage(`products.${idx}.image`, product.image, product.name, '<div class="product-placeholder">📦</div>')}
                                         </div>
                                     </div>
 
@@ -4366,35 +4599,35 @@
                                                     <div class="strategy-icon">👤</div>
                                                     <div class="strategy-text">
                                                         <span class="strategy-label">타겟 고객</span>
-                                                        <span class="strategy-value">${targetAudience}</span>
+                                                        <span class="strategy-value">${edt('strategy.target', vTarget, { ph: '타겟 고객' })}</span>
                                                     </div>
                                                 </div>
                                                 <div class="strategy-row">
                                                     <div class="strategy-icon">🎯</div>
                                                     <div class="strategy-text">
                                                         <span class="strategy-label">매칭 셀러</span>
-                                                        <span class="strategy-value">${targetSeller}</span>
+                                                        <span class="strategy-value">${edt('strategy.seller', vSeller, { ph: '매칭 셀러' })}</span>
                                                     </div>
                                                 </div>
                                                 <div class="strategy-row">
                                                     <div class="strategy-icon">📢</div>
                                                     <div class="strategy-text">
                                                         <span class="strategy-label">홍보 채널</span>
-                                                        <span class="strategy-value">${pStrategy.salesChannel}</span>
+                                                        <span class="strategy-value">${edt('strategy.channel', vChannel, { ph: '홍보 채널' })}</span>
                                                     </div>
                                                 </div>
                                                 <div class="strategy-row">
                                                     <div class="strategy-icon">📱</div>
                                                     <div class="strategy-text">
                                                         <span class="strategy-label">콘텐츠 유형</span>
-                                                        <span class="strategy-value">${contentType}</span>
+                                                        <span class="strategy-value">${edt('strategy.content', vContent, { ph: '콘텐츠 유형' })}</span>
                                                     </div>
                                                 </div>
                                                 <div class="strategy-row">
                                                     <div class="strategy-icon">🏷️</div>
                                                     <div class="strategy-text">
                                                         <span class="strategy-label">프로모션</span>
-                                                        <span class="strategy-value">${pStrategy.promoStrategy}</span>
+                                                        <span class="strategy-value">${edt('strategy.promo', vPromo, { ph: '프로모션' })}</span>
                                                         <span class="strategy-sub">모여라딜 기획 · 공급사 지원 시 더 활성화</span>
                                                     </div>
                                                 </div>
@@ -4404,30 +4637,31 @@
 
                                     <!-- 오른쪽: 핵심 포인트 & 예상 성과 -->
                                     <div class="product-points-col">
-                                        ${displaySellingPoints.length > 0 ? `
+                                        ${(appealList.length > 0 || editMode) ? `
                                         <div class="points-card">
                                             <div class="points-header">
                                                 <i class="fas fa-check-circle"></i>
                                                 <span>핵심 소구점</span>
-                                                ${hasImageAnalysis ? '<span class="ai-tag">AI</span>' : ''}
+                                                ${hasImageAnalysis && !editMode ? '<span class="ai-tag">AI</span>' : ''}
                                             </div>
-                                            <ul class="points-list">
-                                                ${displaySellingPoints.map(sp => `<li>${sp}</li>`).join('')}
+                                            <ul class="points-list" data-list="appealPoints">
+                                                ${appealList.map((sp, i) => `<li>${edt('appealPoints.' + i, sp, { ph: '소구점' })}${editMode ? `<button type="button" class="ed-del ed-only" data-del="appealPoints.${i}" title="삭제">×</button>` : ''}</li>`).join('')}
                                             </ul>
+                                            ${editMode ? `<button type="button" class="ed-add ed-only" data-add="appealPoints">+ 소구점 추가</button>` : ''}
                                         </div>
                                         ` : ''}
                                         <div class="metrics-card">
                                             <div class="metrics-row">
                                                 <div class="metric-item">
-                                                    <div class="metric-value">${hasAnalysis ? analysis.expectedSales : pStrategy.salesEstimate}</div>
+                                                    <div class="metric-value">${edt('kpi.sales', vSales, { ph: '예상 판매' })}</div>
                                                     <div class="metric-label">예상 판매</div>
                                                 </div>
                                                 <div class="metric-item">
-                                                    <div class="metric-value">${hasAnalysis ? analysis.expectedContent : pStrategy.contentCount}</div>
+                                                    <div class="metric-value">${edt('kpi.contents', vContents, { ph: '콘텐츠' })}</div>
                                                     <div class="metric-label">콘텐츠</div>
                                                 </div>
                                                 <div class="metric-item">
-                                                    <div class="metric-value">${pStrategy.settlementDays}</div>
+                                                    <div class="metric-value">${edt('kpi.settle', vSettle, { ph: '정산' })}</div>
                                                     <div class="metric-label">정산</div>
                                                 </div>
                                             </div>
@@ -4533,15 +4767,30 @@
             // 다음 슬라이드 번호 계산 (상품 슬라이드 이후)
             const nextSlide = slideNum + productCount;
 
-            // GIF 콘텐츠 URL (supplier/index.html 엠버서더 섹션과 동일)
-            const reelsGifs = [
-                'https://ecimg.cafe24img.com/pg2246b37345376080/moyeora02/web/upload/wz/gif1.gif',
-                'https://ecimg.cafe24img.com/pg2246b37345376080/moyeora02/web/upload/wz/gif2.gif',
-                'https://ecimg.cafe24img.com/pg2246b37345376080/moyeora02/web/upload/wz/gif3.gif',
-                'https://ecimg.cafe24img.com/pg2246b37345376080/moyeora02/web/upload/wz/gif4.gif',
-                'https://ecimg.cafe24img.com/pg2246b37345376080/moyeora02/web/upload/wz/gif5.gif',
-                'https://ecimg.cafe24img.com/pg2246b37345376080/moyeora02/web/upload/wz/gif6.gif'
-            ];
+            // 커버 릴스 미디어 — 어드민에서 reelsMedia 로 지정하면 사용, 없으면 기본 6 GIF(DEFAULT_REELS)
+            const reelsMediaRaw = (Array.isArray(proposalData.reelsMedia) && proposalData.reelsMedia.length)
+                ? proposalData.reelsMedia : DEFAULT_REELS;
+            // {type:'gif'|'video', url, label} 로 정규화 (문자열이면 gif 로 간주)
+            const reelsItems = reelsMediaRaw
+                .map(m => (typeof m === 'string')
+                    ? { type: 'gif', url: m, label: '' }
+                    : { type: (m.type === 'video' ? 'video' : 'gif'), url: (m.url || ''), label: (m.label || '') })
+                .filter(m => m.url);
+            // 인디케이터/도트 개수 계산용 URL 배열
+            const reelsGifs = reelsItems.map(m => m.url);
+            // 릴스 셀 렌더 — YouTube / 동영상(.mp4 등·firebasestorage) / 이미지(GIF·PNG·JPG) 자동 판별
+            // 영상은 muted loop autoplay playsinline 으로 검은 박스 없이 자동재생, 이미지는 전역 onerror 폴백 적용
+            const reelCell = (m, i) => {
+                const url = m.url || '';
+                const yt = url.match(/(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|shorts\/))([\w-]{11})/);
+                if (yt) return `<iframe src="https://www.youtube.com/embed/${yt[1]}?autoplay=1&mute=1&loop=1&playlist=${yt[1]}&controls=0&playsinline=1&modestbranding=1" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen style="width:100%;height:100%;border:0;object-fit:cover;"></iframe>`;
+                const isImg = /\.(gif|png|jpe?g|webp|avif)(\?|$|&|%3F)/i.test(url);
+                const isVid = /\.(mp4|webm|mov|m4v|ogv)(\?|$|&|%3F)/i.test(url);
+                if (isVid || (m.type === 'video' && !isImg)) {
+                    return `<video src="${url}" autoplay muted loop playsinline preload="metadata" style="width:100%;height:100%;object-fit:cover;background:#000;"></video>`;
+                }
+                return `<img src="${url}" alt="셀러 콘텐츠 ${i + 1}" loading="lazy">`;
+            };
 
             container.innerHTML = `
                 <!-- 슬라이드 1: 커버 -->
@@ -4552,7 +4801,7 @@
                             <!-- 왼쪽: 텍스트 -->
                             <div class="cover-text-col">
                                 <div class="cover-badge fade-in">${template.icon} ${template.name} 맞춤 제안서</div>
-                                <div class="cover-supplier fade-in delay-1">${proposalData.companyName || '공급사'}님을 위한</div>
+                                <div class="cover-supplier fade-in delay-1">${editMode ? edt('companyName', proposalData.companyName || '', { ph: '공급사명' }) : (proposalData.companyName || '공급사')}님을 위한</div>
                                 <h1 class="cover-title fade-in delay-2">
                                     모여라딜과 함께<br>
                                     <span class="highlight">확실한 판매</span>를<br>
@@ -4588,9 +4837,9 @@
                                         <!-- 릴스 캐러셀 -->
                                         <div class="reels-carousel" id="reelsCarousel">
                                             <div class="reels-track" id="reelsTrack">
-                                                ${reelsGifs.map((gif, i) => `
+                                                ${reelsItems.map((m, i) => `
                                                     <div class="reel-item" data-index="${i}">
-                                                        <img src="${gif}" alt="셀러 콘텐츠 ${i + 1}">
+                                                        ${reelCell(m, i)}
                                                     </div>
                                                 `).join('')}
                                             </div>
@@ -4599,6 +4848,25 @@
                                 </div>
                             </div>
                         </div>
+                        ${editMode ? `
+                        <div class="ed-reels-panel ed-only">
+                            <div class="ed-panel-title">📱 릴스 미디어 <span>영상은 .mp4 / firebasestorage URL · 이미지는 GIF·PNG·JPG</span></div>
+                            <div class="ed-reels-list" data-list="reelsMedia">
+                                ${reelsItems.map((m, i) => `
+                                    <div class="ed-reels-row">
+                                        <select class="ed-input ed-reels-type" data-edit="reelsMedia.${i}.type" data-rerender="1">
+                                            <option value="gif" ${m.type !== 'video' ? 'selected' : ''}>이미지/GIF</option>
+                                            <option value="video" ${m.type === 'video' ? 'selected' : ''}>영상</option>
+                                        </select>
+                                        <input class="ed-input ed-reels-url" type="text" placeholder="미디어 URL" value="${escAttr(m.url)}" data-edit="reelsMedia.${i}.url" data-rerender="1">
+                                        <input class="ed-input ed-reels-label" type="text" placeholder="라벨(선택)" value="${escAttr(m.label || '')}" data-edit="reelsMedia.${i}.label">
+                                        <button type="button" class="ed-del" data-del="reelsMedia.${i}" title="삭제">×</button>
+                                    </div>
+                                `).join('')}
+                            </div>
+                            <button type="button" class="ed-add" data-add="reelsMedia">+ 릴스 추가</button>
+                        </div>
+                        ` : ''}
                     </div>
                     <div class="cover-meta fade-in delay-5">${dateStr}</div>
                 </section>
@@ -4717,25 +4985,27 @@
                     <div class="slide-content">
                         <div class="section-tag fade-in" style="color: var(--accent);">BRAND STORY</div>
                         <h2 class="section-title fade-in delay-1" style="color: var(--text-dark);">
-                            <span class="highlight">${proposalData.companyName}</span>을<br>소개합니다
+                            <span class="highlight">${editMode ? edt('companyName', proposalData.companyName || '', { ph: '공급사명' }) : (proposalData.companyName || '')}</span>을<br>소개합니다
                         </h2>
                         <div class="brand-layout">
                             <div class="brand-content fade-in delay-2">
-                                ${brand.slogan ? `
-                                <p class="brand-slogan">${brand.slogan}</p>
+                                ${(brand.slogan || editMode) ? `
+                                <p class="brand-slogan">${edt('brand.slogan', brand.slogan, { ph: '브랜드 슬로건' })}</p>
                                 ` : ''}
-                                ${brand.story ? `
+                                ${(brand.story || editMode) ? `
                                 <div class="brand-story">
                                     <div class="brand-story-title">
                                         <i class="fas fa-heart"></i>
                                         브랜드 철학
                                     </div>
-                                    <p class="brand-story-text">${brand.story}</p>
+                                    <p class="brand-story-text">${edt('brand.story', brand.story, { ph: '브랜드 스토리', block: true })}</p>
                                 </div>
                                 ` : ''}
-                                ${brand.keywords ? `
+                                ${(brand.keywords || editMode) ? `
                                 <div class="brand-keywords">
-                                    ${brand.keywords.split(',').map(k => `<span class="brand-keyword">${k.trim()}</span>`).join('')}
+                                    ${editMode
+                                        ? edt('brand.keywords', brand.keywords || '', { ph: '키워드 (쉼표로 구분: 예) 안전, 저자극)' })
+                                        : (brand.keywords || '').split(',').map(k => `<span class="brand-keyword">${k.trim()}</span>`).join('')}
                                 </div>
                                 ` : ''}
                             </div>
@@ -4812,8 +5082,8 @@
                                                         ? `<div class="insta-carousel-item"><img src="${products[0].image}" alt="상품" data-ph="product"></div>`
                                                         : ''
                                                     }
-                                                    ${reelsGifs.slice(0, 4).map((gif, i) => `
-                                                        <div class="insta-carousel-item"><img src="${gif}" alt="셀러 콘텐츠 ${i + 1}"></div>
+                                                    ${reelsItems.slice(0, 4).map((m, i) => `
+                                                        <div class="insta-carousel-item">${reelCell(m, i)}</div>
                                                     `).join('')}
                                                 </div>
                                                 <div class="insta-carousel-dots">
@@ -4843,8 +5113,8 @@
                                             </div>
                                             <div class="tiktok-video-area">
                                                 <div class="tiktok-carousel" id="tiktokCarousel">
-                                                    ${reelsGifs.map((gif, i) => `
-                                                        <div class="tiktok-carousel-item"><img src="${gif}" alt="셀러 콘텐츠 ${i + 1}"></div>
+                                                    ${reelsItems.map((m, i) => `
+                                                        <div class="tiktok-carousel-item">${reelCell(m, i)}</div>
                                                     `).join('')}
                                                 </div>
                                                 <!-- TikTok UI 오버레이 -->
@@ -5931,6 +6201,235 @@
 
         function hideLoading() {
             document.getElementById('loadingScreen').style.display = 'none';
+        }
+
+        // ============================================================
+        // ===== 인라인 편집모드(WYSIWYG) =====
+        // ============================================================
+
+        // 편집모드 진입 시, 화면에 보이는 값(자동 생성 전략/KPI/소구점, 기본 릴스)을
+        // proposalData 에 시드해서 "보이는 그대로" 편집·저장되게 한다.
+        function seedEditDefaults() {
+            if (!proposalData) return;
+            proposalData.brand = proposalData.brand || {};
+            const products = proposalData.products || [];
+            if (products.length) {
+                const p0 = products[0];
+                const cat = p0.category || proposalData.category || 'default';
+                const tmpl = categoryTemplates[cat] || categoryTemplates.default;
+                let ps = {};
+                try { ps = generateProductStrategy(p0, 0, cat, tmpl) || {}; } catch (e) { ps = {}; }
+                const a0 = p0.analysis || {}, ia0 = p0.imageAnalysis || {};
+                proposalData.strategy = Object.assign({
+                    target: ps.targetAudience || '',
+                    seller: ia0.targetSeller || a0.targetSeller || ((ps.sellerType || '') + ' 셀러').trim(),
+                    channel: ps.salesChannel || '',
+                    content: ia0.contentType || a0.contentType || ps.contentType || '',
+                    promo: ps.promoStrategy || ''
+                }, proposalData.strategy || {});
+                proposalData.kpi = Object.assign({
+                    sales: a0.expectedSales || ps.salesEstimate || '',
+                    contents: a0.expectedContent || ps.contentCount || '',
+                    settle: ps.settlementDays || ''
+                }, proposalData.kpi || {});
+                if (!Array.isArray(proposalData.appealPoints) || !proposalData.appealPoints.length) {
+                    const pts = [...new Set([...(a0.sellingPoints || []), ...(ia0.sellingPoints || [])])].slice(0, 3);
+                    if (pts.length) proposalData.appealPoints = pts;
+                }
+            }
+            if (!Array.isArray(proposalData.reelsMedia) || !proposalData.reelsMedia.length) {
+                proposalData.reelsMedia = DEFAULT_REELS.map(u => ({ type: 'gif', url: u, label: '' }));
+            }
+        }
+
+        // 현재 화면 상단에 보이는 슬라이드 id (재렌더 후 위치 복원용)
+        function currentVisibleSlideId() {
+            let best = null, bestDist = Infinity;
+            document.querySelectorAll('#slidesContainer .slide').forEach(s => {
+                const top = Math.abs(s.getBoundingClientRect().top);
+                if (top < bestDist) { bestDist = top; best = s.id; }
+            });
+            return best;
+        }
+
+        // DOM 의 모든 [data-edit] 값을 proposalData 로 반영
+        function applyEditEl(el) {
+            const path = el.getAttribute('data-edit');
+            if (!path) return;
+            let val;
+            if (el.tagName === 'INPUT' || el.tagName === 'SELECT' || el.tagName === 'TEXTAREA') {
+                val = el.value;
+            } else {
+                val = el.textContent;
+            }
+            if (el.getAttribute('data-type') === 'number') {
+                const digits = String(val).replace(/[^\d.-]/g, '');
+                val = digits === '' ? '' : Number(digits);
+            } else if (typeof val === 'string') {
+                val = val.trim();
+            }
+            setByPath(proposalData, path, val);
+        }
+        function syncFromDOM() {
+            document.querySelectorAll('#slidesContainer [data-edit]').forEach(applyEditEl);
+        }
+
+        // 편집 상태 그대로 슬라이드 다시 그리기 (구조 변경/이미지·릴스 URL 변경 시)
+        function rerenderPreview() {
+            syncFromDOM();
+            const keepId = currentVisibleSlideId();
+            renderSlides();
+            try { generateSidebarThumbs(); } catch (e) {}
+            try { initReelsCarousel(); } catch (e) {}
+            try { initMockupCarousels(); } catch (e) {}
+            try { setupNavigation(); } catch (e) {}
+            if (keepId) { const el = document.getElementById(keepId); if (el) el.scrollIntoView({ block: 'start' }); }
+            markDirty();
+        }
+        function scheduleRerender() {
+            clearTimeout(rerenderTimer);
+            rerenderTimer = setTimeout(rerenderPreview, 80);
+        }
+
+        function markDirty() {
+            editDirty = true;
+            const b = document.getElementById('edSave');
+            if (b) { b.classList.add('dirty'); }
+        }
+
+        function enterEditMode() {
+            if (!proposalData) return;
+            seedEditDefaults();
+            editMode = true;
+            document.body.classList.add('edit-mode');
+            const keepId = currentVisibleSlideId();
+            renderSlides();
+            try { generateSidebarThumbs(); } catch (e) {}
+            try { initReelsCarousel(); } catch (e) {}
+            try { initMockupCarousels(); } catch (e) {}
+            try { setupNavigation(); } catch (e) {}
+            if (keepId) { const el = document.getElementById(keepId); if (el) el.scrollIntoView({ block: 'start' }); }
+            const t = document.getElementById('edToggle');
+            if (t) t.innerHTML = '<i class="fas fa-eye"></i> 미리보기';
+            const sel = document.getElementById('edDealStatus');
+            if (sel) sel.value = proposalData.dealPriceStatus || 'negotiating';
+        }
+        function exitEditMode() {
+            syncFromDOM();
+            editMode = false;
+            document.body.classList.remove('edit-mode');
+            const keepId = currentVisibleSlideId();
+            renderSlides();
+            try { generateSidebarThumbs(); } catch (e) {}
+            try { initReelsCarousel(); } catch (e) {}
+            try { initMockupCarousels(); } catch (e) {}
+            try { setupNavigation(); } catch (e) {}
+            if (keepId) { const el = document.getElementById(keepId); if (el) el.scrollIntoView({ block: 'start' }); }
+            const t = document.getElementById('edToggle');
+            if (t) t.innerHTML = '<i class="fas fa-pen"></i> 편집모드';
+        }
+        function toggleEditMode() { editMode ? exitEditMode() : enterEditMode(); }
+
+        // 저장 — proposalDerivatives/<id> 문서 업데이트
+        async function saveProposal() {
+            if (!proposalId || !proposalData) return;
+            syncFromDOM();
+            const btn = document.getElementById('edSave');
+            const orig = btn ? btn.innerHTML : '';
+            if (btn) { btn.disabled = true; btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> 저장 중...'; }
+            const payload = {
+                companyName: proposalData.companyName || '',
+                products: proposalData.products || [],
+                brand: proposalData.brand || {},
+                strategy: proposalData.strategy || {},
+                kpi: proposalData.kpi || {},
+                appealPoints: proposalData.appealPoints || [],
+                reelsMedia: proposalData.reelsMedia || [],
+                dealPriceStatus: proposalData.dealPriceStatus || 'negotiating',
+                updatedAt: Date.now()
+            };
+            try {
+                await db.collection('proposalDerivatives').doc(proposalId).update(payload);
+                editDirty = false;
+                if (btn) { btn.classList.remove('dirty'); btn.innerHTML = '<i class="fas fa-check"></i> 저장됨'; }
+                showToast('저장되었습니다 ✅');
+                setTimeout(() => { if (btn) { btn.disabled = false; btn.innerHTML = orig || '<i class="fas fa-save"></i> 저장'; } }, 1500);
+            } catch (e) {
+                console.error('저장 오류:', e);
+                if (btn) { btn.disabled = false; btn.innerHTML = orig; }
+                showToast('저장 실패: ' + (e && e.message ? e.message : '권한/네트워크 확인'), true);
+            }
+        }
+
+        function showToast(msg, isErr) {
+            let t = document.getElementById('edToast');
+            if (!t) { t = document.createElement('div'); t.id = 'edToast'; document.body.appendChild(t); }
+            t.textContent = msg;
+            t.className = 'ed-toast show' + (isErr ? ' err' : '');
+            clearTimeout(t._timer);
+            t._timer = setTimeout(() => { t.className = 'ed-toast'; }, 2600);
+        }
+
+        // 이벤트 위임 — 편집 입력/구조 변경 처리
+        function bindEditEvents() {
+            const root = document.getElementById('slidesContainer');
+            // 텍스트(컨텐트에디터블·일반 input) 즉시 반영 (재렌더 없이 — 포커스 유지)
+            root.addEventListener('input', (e) => {
+                const el = e.target;
+                if (el.hasAttribute && el.hasAttribute('data-edit') && !el.hasAttribute('data-rerender')) {
+                    applyEditEl(el); markDirty();
+                }
+            });
+            // 이미지/릴스 URL·타입 등 미리보기 갱신이 필요한 항목은 변경 시 재렌더
+            root.addEventListener('change', (e) => {
+                const el = e.target;
+                if (el.hasAttribute && el.hasAttribute('data-edit') && el.hasAttribute('data-rerender')) {
+                    applyEditEl(el); scheduleRerender();
+                }
+            });
+            // 추가/삭제 버튼
+            root.addEventListener('click', (e) => {
+                const add = e.target.closest('[data-add]');
+                const del = e.target.closest('[data-del]');
+                if (add) {
+                    e.preventDefault();
+                    const key = add.getAttribute('data-add');
+                    if (key === 'appealPoints') { proposalData.appealPoints = proposalData.appealPoints || []; proposalData.appealPoints.push(''); }
+                    else if (key === 'reelsMedia') { proposalData.reelsMedia = proposalData.reelsMedia || []; proposalData.reelsMedia.push({ type: 'gif', url: '', label: '' }); }
+                    rerenderPreview();
+                } else if (del) {
+                    e.preventDefault();
+                    const m = del.getAttribute('data-del').match(/^(\w+)\.(\d+)$/);
+                    if (m && Array.isArray(proposalData[m[1]])) { proposalData[m[1]].splice(Number(m[2]), 1); rerenderPreview(); }
+                }
+            });
+            // 엔터로 줄바꿈 방지(블록 필드 제외)
+            root.addEventListener('keydown', (e) => {
+                const el = e.target;
+                if (e.key === 'Enter' && el.classList && el.classList.contains('ed-field') && !el.hasAttribute('data-block')) {
+                    e.preventDefault(); el.blur();
+                }
+            });
+        }
+
+        // 편집 툴바 초기화 (렌더 후 1회)
+        function setupEditToolbar() {
+            const toggle = document.getElementById('edToggle');
+            const save = document.getElementById('edSave');
+            const dealSel = document.getElementById('edDealStatus');
+            if (toggle) toggle.addEventListener('click', toggleEditMode);
+            if (save) save.addEventListener('click', saveProposal);
+            if (dealSel) dealSel.addEventListener('change', () => {
+                proposalData.dealPriceStatus = dealSel.value;
+                rerenderPreview();
+            });
+            bindEditEvents();
+            window.addEventListener('beforeunload', (e) => {
+                if (editMode && editDirty) { e.preventDefault(); e.returnValue = ''; }
+            });
+            // ?edit=1 이면 자동 진입
+            const params = new URLSearchParams(window.location.search);
+            if (params.get('edit') === '1') enterEditMode();
         }
 
         // 초기화


### PR DESCRIPTION
## 배경
공급사 맞춤 제안서 뷰어(`supplier/custom-proposal/view.html`, 공개 주소 `partner-moyeoradeal.kr/supplier/custom-proposal/view.html?id=...`)에 **슬라이드별 인라인 편집모드(WYSIWYG)** 를 추가하고, 영상 릴스·엑박·모바일 문제를 함께 해결했습니다. 기존 슬라이드 덱 디자인과 데스크탑 레이아웃은 그대로 유지합니다.

> 이 브랜치는 직전 모바일/엑박 수정(#851)을 포함합니다. 이 PR을 머지하면 #851은 닫아도 됩니다.

## 1. 인라인 편집모드 (WYSIWYG)
- 우상단 **"✏️ 편집모드"** 토글 + `?edit=1` 자동 진입
- 슬라이드 위에서 그 자리에서 직접 수정 (contenteditable + 입력칸):
  - **회사명**, **상품**(상품명·정가·딜가·할인율·이미지 URL·상세 URL)
  - **브랜드**(슬로건·스토리·키워드), **공구 전략**(타겟/셀러/채널/콘텐츠/프로모션)
  - **KPI**(예상판매·콘텐츠·정산), **핵심 소구점**(추가/삭제)
  - **릴스 미디어**(타입/URL/라벨 · 추가/삭제), **딜가 상태**(협의중/확정) 토글
- 편집모드 진입 시, 화면에 보이는 자동생성 전략/KPI/소구점·기본 릴스를 `proposalData`에 시드 → **"보이는 그대로"** 편집·저장
- **"💾 저장"** → `proposalDerivatives/<id>` 문서 `update` (companyName, products, brand, strategy, kpi, appealPoints, reelsMedia, dealPriceStatus)
- 숫자 필드는 숫자로 파싱, 이미지/릴스 URL 변경은 즉시 미리보기 재렌더, 저장 안 한 채 이탈 시 경고

## 2. 릴스 영상 자동재생
- 기존 렌더러는 `reelsMedia`를 **무시하고 하드코딩 GIF 6개만** 그렸습니다 → 어드민에서 넣은 firebasestorage `.mp4` 영상이 검은 박스/미표시였던 원인.
- 이제 `reelsMedia`를 읽어 **영상은 `<video muted loop autoplay playsinline>`** 으로 자동재생, YouTube·이미지(GIF/PNG/JPG)는 자동 판별. 커버/인스타/틱톡 목업 모두 반영.

## 3. 상품 이미지·릴스 엑박 방지
- 깨진/빈 이미지는 인라인 SVG **"상품 이미지" / "콘텐츠 준비중"** 플레이스홀더로 대체 (전역 `error` 캡처).

## 4. 모바일 반응형
- 편집 툴바·릴스 편집 패널 포함 **폭 390px 가로 넘침 없음**.

## 검증 (Chromium)
- 영상: `autoplay/muted/loop/playsinline` 모두 적용 확인, firebasestorage `.mp4?alt=media` 인식 ✓
- 편집모드: 인라인 텍스트/숫자(숫자형 저장)/소구점 추가·삭제/이미지·릴스 URL 입력 동작, 저장 시 9개 키 update payload 확인 ✓
- 가로 넘침: 편집모드 포함 390px `scrollWidth === clientWidth` ✓
- 비편집(게시) 화면은 기존과 동일하게 렌더(편집 잔재 없음) ✓

## 참고
- 서빙 파일 `view.html`만 수정했습니다. 같은 폴더의 더블 확장자 업로드 아티팩트 `view.html.html`(미서빙)은 손대지 않았습니다.
- 저장은 Firestore 쓰기 권한 규칙을 따릅니다(현재 조회수 증가와 동일 경로). 편집 접근 제어가 필요하면 알려주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VyNqbxyTxTJXgem8WkYL6f)_