### PR TITLE
Add direct camera capture option for shot uploads

### DIFF
--- a/supplier/guide/index.html
+++ b/supplier/guide/index.html
@@ -74,7 +74,8 @@
     .shot-cap{font-size:13px;color:var(--sub);background:var(--bg);border-radius:8px;padding:8px 10px;line-height:1.4;}
     .shot-cap b{color:var(--brand-d);font-weight:700;font-size:11px;display:block;margin-bottom:2px;}
     .shot-up{margin-top:9px;}
-    .shot-upbtn{display:block;text-align:center;font-size:12px;font-weight:700;border:1px dashed #ffd49c;background:#fffaf3;color:var(--brand-d);border-radius:9px;padding:10px;cursor:pointer;}
+    .shot-upbtn{display:block;text-align:center;font-size:13px;font-weight:700;border:none;background:var(--brand);color:#fff;border-radius:9px;padding:12px;cursor:pointer;}
+    .shot-pick{display:block;text-align:center;margin-top:7px;font-size:11px;color:var(--tert);cursor:pointer;text-decoration:underline;}
     .shot-file{display:flex;align-items:center;gap:8px;margin-top:8px;background:var(--okl);border:1px solid #c8efd9;border-radius:9px;padding:7px 10px;}
     .shot-file .ic{width:30px;height:30px;border-radius:7px;background-size:cover;background-position:center;background:linear-gradient(135deg,#fc9600,#e08600);color:#fff;display:flex;align-items:center;justify-content:center;font-size:15px;text-decoration:none;flex-shrink:0;}
     .shot-file .fn{font-size:12px;font-weight:600;flex:1;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:var(--ink);text-decoration:none;}
@@ -375,7 +376,10 @@
               <div class="shot-scene">${esc(s.scene || '')}</div>
               <div class="shot-cap"><b>자막</b>"${esc(s.subtitle || '')}"</div>
               ${ups.map(u => `<div class="shot-file">${fileThumb(u)}<a class="fn" href="${u.url}" target="_blank" rel="noopener">${esc(u.name)}</a><button class="fx" onclick="delUp('${esc(u.path)}')">삭제</button></div>`).join('')}
-              <div class="shot-up"><label class="shot-upbtn">📎 ${ok ? '영상 더 올리기' : '이 컷 촬영본 올리기'}<input type="file" multiple accept="image/*,video/*" style="display:none" onchange="pickShot(${s.order},this)"></label></div>
+              <div class="shot-up">
+                <label class="shot-upbtn">🎬 ${ok ? '다시 촬영해서 올리기' : '촬영해서 바로 올리기'}<input type="file" accept="video/*" capture="environment" style="display:none" onchange="pickShot(${s.order},this)"></label>
+                <label class="shot-pick">갤러리에서 선택<input type="file" multiple accept="image/*,video/*" style="display:none" onchange="pickShot(${s.order},this)"></label>
+              </div>
               <div class="shot-prog" id="prog${s.order}"></div>
             </div>`;
         });


### PR DESCRIPTION
컷별 촬영본 업로드 컨트롤을 둘로 분리합니다.

- 메인 버튼: "촬영해서 바로 올리기" (`capture="environment"`로 카메라 바로 실행)
- 보조 링크: "갤러리에서 선택" (기존 다중 파일 선택)
- 관련 `.shot-upbtn` 스타일 업데이트 및 `.shot-pick` 스타일 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNXzvmSQQYndmGa7Sm1d5N)_