### PR TITLE
Switch storyboard editing to per-shot inline edit

### DIFF
--- a/supplier/guide/index.html
+++ b/supplier/guide/index.html
@@ -79,6 +79,7 @@
     .ed-i{flex:1;border:1px solid var(--line);border-radius:8px;padding:7px 10px;font-family:inherit;font-size:13px;outline:none;}
     .ed-t{display:block;width:100%;margin-top:7px;border:1px solid var(--line);border-radius:8px;padding:8px 10px;font-family:inherit;font-size:13px;line-height:1.45;outline:none;resize:vertical;min-height:42px;}
     .ed-i:focus,.ed-t:focus{border-color:var(--brand);}
+    .shot-edit{font-family:inherit;font-size:11px;font-weight:700;color:var(--brand-d);background:#fff8f0;border:1px solid #ffe1b8;border-radius:7px;padding:3px 8px;cursor:pointer;margin-left:6px;}
     .shot-file{display:flex;align-items:center;gap:8px;margin-top:8px;background:var(--okl);border:1px solid #c8efd9;border-radius:9px;padding:7px 10px;}
     .shot-file .ic{width:30px;height:30px;border-radius:7px;background-size:cover;background-position:center;background:linear-gradient(135deg,#fc9600,#e08600);color:#fff;display:flex;align-items:center;justify-content:center;font-size:15px;text-decoration:none;flex-shrink:0;}
     .shot-file .fn{font-size:12px;font-weight:600;flex:1;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;color:var(--ink);text-decoration:none;}
@@ -140,7 +141,7 @@
     let decided = false;
     let page = 'guide';   // guide | upload
     let genPending = null; // 'reels' | 'caption' | null
-    let editingSb = false;
+    let editingShot = null;
     let _unsub = null;
 
     const esc = s => { if (s == null) return ''; const d = document.createElement('div'); d.textContent = String(s); return d.innerHTML; };
@@ -337,33 +338,27 @@
           <div class="card">
             <div class="sb-head"><span><span class="type-badge">${TYPES[typeOf(g)] || ''} ${esc(typeOf(g))}</span> <span class="sb-theme">🎭 ${esc(sb.theme || '')}</span></span><span class="sb-total">${total}컷 · ${esc(sb.totalDuration || '')}</span></div>
             <div class="sb-title">${esc(sb.title || '최종 릴스 구성안')}</div>
-            <div style="font-size:12px;color:var(--tert);margin-top:5px">아래 컷 순서대로 촬영하고 캡션을 준비한 뒤, 업로드로 넘어가세요.</div>
-            <div style="display:flex;gap:8px;margin-top:10px;flex-wrap:wrap">
-              ${editingSb ? '' : `<button class="regen" style="margin:0" onclick="toggleEditSb()">✏️ 구성안 수정</button>`}
-              ${done === 0 && !editingSb ? `<button class="regen" style="margin:0" onclick="regen()">🔄 다시 만들기</button>` : ''}
-            </div>
+            <div style="font-size:12px;color:var(--tert);margin-top:5px">아래 컷 순서대로 촬영하고 캡션을 준비한 뒤, 업로드로 넘어가세요. (컷마다 ✏️ 수정 가능)</div>
+            ${done === 0 ? `<button class="regen" onclick="regen()">🔄 구성안 다시 만들기</button>` : ''}
           </div>`;
-        if (editingSb) {
-          shotsOf(g).forEach(s => {
+        shotsOf(g).forEach(s => {
+          const ok = shotUp(g, s.order).length > 0;
+          if (editingShot === s.order) {
             h += `
               <div class="shot">
                 <div class="shot-t"><span class="shot-n">${s.order}</span><input class="ed-i" id="edDur_${s.order}" value="${esc(s.duration || '')}" placeholder="길이 (예: 1.5초)"></div>
                 <textarea class="ed-t" id="edScene_${s.order}" placeholder="장면 설명">${esc(s.scene || '')}</textarea>
                 <textarea class="ed-t" id="edSub_${s.order}" placeholder="자막">${esc(s.subtitle || '')}</textarea>
+                <div style="display:flex;gap:8px;margin-top:8px"><button class="btn-main" style="flex:1;padding:10px" onclick="saveShot(${s.order})">💾 저장</button><button class="cap-regen" onclick="cancelShot()">취소</button></div>
               </div>`;
-          });
-          h += `<div style="padding:2px 18px 0;display:flex;gap:8px"><button class="btn-main" style="flex:1" onclick="saveSb()">💾 저장</button><button class="cap-regen" onclick="cancelSb()">취소</button></div>`;
-          h += `<div class="trust">수정 후 저장하면 셀러·관리자 화면에 바로 반영돼요</div>`;
-          root.innerHTML = h; return;
-        }
-        shotsOf(g).forEach(s => {
-          const ok = shotUp(g, s.order).length > 0;
-          h += `
-            <div class="shot ${ok ? 'done' : ''}">
-              <div class="shot-t"><span class="shot-n">${s.order}</span><span class="shot-dur">${esc(s.duration || '')}</span><span class="shot-stat ${ok ? 'ok' : 'no'}">${ok ? '✓ 업로드됨' : '🎬 촬영'}</span></div>
-              <div class="shot-scene">${esc(s.scene || '')}</div>
-              <div class="shot-cap"><b>자막</b>"${esc(s.subtitle || '')}"</div>
-            </div>`;
+          } else {
+            h += `
+              <div class="shot ${ok ? 'done' : ''}">
+                <div class="shot-t"><span class="shot-n">${s.order}</span><span class="shot-dur">${esc(s.duration || '')}</span><span class="shot-stat ${ok ? 'ok' : 'no'}">${ok ? '✓ 업로드됨' : '🎬 촬영'}</span><button class="shot-edit" onclick="editShot(${s.order})">✏️ 수정</button></div>
+                <div class="shot-scene">${esc(s.scene || '')}</div>
+                <div class="shot-cap"><b>자막</b>"${esc(s.subtitle || '')}"</div>
+              </div>`;
+          }
         });
         const cap = g.caption;
         h += `
@@ -429,14 +424,14 @@
     function accept() { decided = true; page = 'guide'; render(); }
     function goPage(p) { page = p; render(); }
     async function regen() { if (!confirm('현재 구성안을 지우고 다시 선택할까요?')) return; await patch({ storyboard: null }); guide.storyboard = null; decided = false; render(); }
-    function toggleEditSb() { editingSb = !editingSb; render(); }
-    function cancelSb() { editingSb = false; render(); }
-    async function saveSb() {
+    function editShot(order) { editingShot = order; render(); }
+    function cancelShot() { editingShot = null; render(); }
+    async function saveShot(order) {
       const sb = sbOf(guide); if (!sb) return;
       const v = id => { const el = document.getElementById(id); return el ? el.value.trim() : ''; };
-      const shots = sb.shots.map(s => ({ ...s, duration: v('edDur_' + s.order), scene: v('edScene_' + s.order), subtitle: v('edSub_' + s.order) }));
+      const shots = sb.shots.map(s => Number(s.order) === Number(order) ? { ...s, duration: v('edDur_' + order), scene: v('edScene_' + order), subtitle: v('edSub_' + order) } : s);
       const storyboard = { ...sb, shots };
-      try { await patch({ storyboard }); guide.storyboard = storyboard; editingSb = false; render(); }
+      try { await patch({ storyboard }); guide.storyboard = storyboard; editingShot = null; render(); }
       catch (e) { alert('저장 실패: ' + (e.message || e)); }
     }
 


### PR DESCRIPTION
전체 구성안 수정 모드를 컷(샷)별 인라인 수정으로 변경합니다.

- 상태 변수 `editingSb` → `editingShot` (현재 편집 중인 컷 order)
- 각 컷에 "✏️ 수정" 버튼, 해당 컷만 길이·장면·자막 인라인 편집/저장/취소
- `toggleEditSb/cancelSb/saveSb` → `editShot/cancelShot/saveShot`
- `.shot-edit` 버튼 스타일 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNXzvmSQQYndmGa7Sm1d5N)_