### PR TITLE
Add group-buy operation guide page

### DIFF
--- a/supplier/guide/gonggu.html
+++ b/supplier/guide/gonggu.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <title>공구 진행 가이드 · 모여라딜</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css">
+  <meta name="theme-color" content="#fc9600">
+  <style>
+    :root{--brand:#fc9600;--brand-d:#e08600;--brand-l:#fff8f0;--ink:#191f28;--sub:#4e5968;--tert:#8b95a1;--line:#e5e8eb;--ok:#00c073;--okl:#ecfdf5;--bg:#f9fafb;}
+    *{box-sizing:border-box;margin:0;padding:0;}
+    body{font-family:'Pretendard',-apple-system,sans-serif;background:var(--bg);color:var(--ink);-webkit-font-smoothing:antialiased;}
+    .wrap{max-width:480px;margin:0 auto;padding-bottom:50px;}
+    .hero{background:#fff;padding:22px 18px 16px;border-bottom:1px solid var(--line);}
+    .hero .hi{font-size:13px;color:var(--tert);}
+    .hero .nm{font-size:23px;font-weight:800;margin:3px 0 8px;}
+    .hero .prod{display:flex;align-items:center;gap:8px;font-size:13px;color:var(--sub);background:var(--bg);border-radius:10px;padding:10px 12px;line-height:1.5;}
+    .nav{display:flex;gap:6px;padding:12px 18px;position:sticky;top:0;z-index:50;background:#fff;border-bottom:1px solid var(--line);overflow-x:auto;}
+    .nav a{flex:0 0 auto;font-size:12px;font-weight:700;color:var(--sub);background:var(--bg);border-radius:99px;padding:6px 12px;text-decoration:none;white-space:nowrap;}
+    .card{background:#fff;border:1px solid var(--line);border-radius:16px;margin:16px 18px;padding:16px;}
+    .step-h{display:flex;align-items:flex-start;gap:12px;margin-bottom:12px;}
+    .step-n{width:30px;height:30px;border-radius:9px;background:var(--brand);color:#fff;font-size:14px;font-weight:800;display:flex;align-items:center;justify-content:center;flex-shrink:0;}
+    .step-t{font-size:16px;font-weight:800;}
+    .step-s{font-size:12px;color:var(--tert);margin-top:2px;line-height:1.45;}
+    .chk{list-style:none;}
+    .chk li{position:relative;font-size:13px;color:var(--sub);line-height:1.55;padding:7px 0 7px 26px;border-top:1px solid var(--line);}
+    .chk li:first-child{border-top:none;}
+    .chk li::before{content:'✓';position:absolute;left:0;top:7px;width:18px;height:18px;border-radius:50%;background:var(--okl);color:var(--ok);font-size:11px;font-weight:800;display:flex;align-items:center;justify-content:center;}
+    .chk li b{color:var(--ink);font-weight:700;}
+    .tip{margin-top:11px;font-size:12px;color:#9a5b00;background:var(--brand-l);border:1px solid #ffe1b8;border-radius:10px;padding:10px 12px;line-height:1.55;}
+    .tip b{font-weight:800;}
+    .warn{margin-top:11px;font-size:12px;color:#b42318;background:#fef3f2;border:1px solid #fecdca;border-radius:10px;padding:10px 12px;line-height:1.55;}
+    .warn b{font-weight:800;}
+    .link-card{display:flex;align-items:center;gap:12px;margin:16px 18px;background:linear-gradient(135deg,#fff8f0,#fff);border:1px solid #ffe1b8;border-radius:16px;padding:15px 16px;text-decoration:none;}
+    .link-card .ic{width:40px;height:40px;border-radius:11px;background:var(--brand);color:#fff;font-size:20px;display:flex;align-items:center;justify-content:center;flex-shrink:0;}
+    .link-card .t{font-size:14px;font-weight:800;color:var(--ink);}
+    .link-card .s{font-size:12px;color:var(--sub);margin-top:1px;}
+    .link-card .go{margin-left:auto;font-size:18px;color:var(--brand-d);font-weight:800;}
+    .sec-lb{font-size:12px;font-weight:800;color:var(--brand-d);padding:8px 18px 0;letter-spacing:.02em;}
+    .trust{font-size:11px;color:var(--tert);text-align:center;padding:18px 14px;line-height:1.6;}
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="hero">
+      <div class="hi">모여라딜 셀러 가이드 🛒</div>
+      <div class="nm">공구 진행 가이드</div>
+      <div class="prod">공구 준비부터 정산까지, 단계별로 무엇을 해야 하는지 한눈에 정리했어요. 위에서부터 순서대로 따라오세요.</div>
+    </div>
+
+    <div class="nav">
+      <a href="#s1">① 준비</a>
+      <a href="#s2">② 콘텐츠</a>
+      <a href="#s3">③ 오픈·홍보</a>
+      <a href="#s4">④ 주문관리</a>
+      <a href="#s5">⑤ 마감·발주</a>
+      <a href="#s6">⑥ 배송·CS</a>
+      <a href="#s7">⑦ 정산</a>
+    </div>
+
+    <a class="link-card" href="./index.html">
+      <span class="ic">🎬</span>
+      <span><span class="t">릴스 촬영 가이드 열기</span><span class="s">공구 홍보 영상은 여기서 구성안·촬영·업로드까지</span></span>
+      <span class="go">→</span>
+    </a>
+
+    <div class="sec-lb">공구 진행 7단계</div>
+
+    <div class="card" id="s1">
+      <div class="step-h"><span class="step-n">1</span><div><div class="step-t">상품 · 조건 확정</div><div class="step-s">무엇을, 얼마에, 얼마나 팔지 먼저 정합니다</div></div></div>
+      <ul class="chk">
+        <li><b>상품 선정</b> — 공구로 내보낼 상품과 옵션(구성/수량)을 확정</li>
+        <li><b>공구가 설정</b> — 정상가 대비 혜택가, 최소 마진 확인</li>
+        <li><b>수량·기간</b> — 목표 수량과 공구 오픈~마감 일정 결정</li>
+        <li><b>재고 확인</b> — 공급사와 발주 가능 수량·리드타임 사전 합의</li>
+      </ul>
+      <div class="tip"><b>TIP</b> 마감일은 발주·배송 리드타임을 역산해서 잡으세요. "마감 다음 날 발주 → N일 뒤 출고"가 지켜지는지 먼저 확인.</div>
+    </div>
+
+    <div class="card" id="s2">
+      <div class="step-h"><span class="step-n">2</span><div><div class="step-t">콘텐츠 준비</div><div class="step-s">보여줄 것과 설명할 것을 만듭니다</div></div></div>
+      <ul class="chk">
+        <li><b>홍보 릴스</b> — 릴스 촬영 가이드로 구성안·촬영·캡션 준비</li>
+        <li><b>상세 설명</b> — 상품 특징·사용법·주의사항을 솔직하게 정리</li>
+        <li><b>가격·혜택 표기</b> — 공구가, 정상가, 마감일을 눈에 띄게</li>
+        <li><b>사진</b> — 실사용·디테일 컷 확보 (과장 없이)</li>
+      </ul>
+      <div class="tip"><b>TIP</b> 릴스는 마감 3~5일 전에 미리 준비해두면 오픈과 동시에 바로 게시할 수 있어요.</div>
+    </div>
+
+    <div class="card" id="s3">
+      <div class="step-h"><span class="step-n">3</span><div><div class="step-t">공구 오픈 · 홍보</div><div class="step-s">열었으면 알려야 팔립니다</div></div></div>
+      <ul class="chk">
+        <li><b>공구 링크 오픈</b> — 주문 페이지/폼 활성화 확인</li>
+        <li><b>피드 게시</b> — 릴스 + 캡션 + 해시태그로 본게시물 업로드</li>
+        <li><b>스토리·하이라이트</b> — 링크 스티커로 유입, 하이라이트에 고정</li>
+        <li><b>마감 리마인드</b> — 오픈 직후 / 중간 / 마감 임박 3회 안내</li>
+      </ul>
+      <div class="warn"><b>협찬(광고)</b>인 경우 게시물·영상에 <b>#광고 · 유료광고 표시</b>를 반드시 넣어주세요. (대가성 콘텐츠 표기 의무)</div>
+    </div>
+
+    <div class="card" id="s4">
+      <div class="step-h"><span class="step-n">4</span><div><div class="step-t">주문 관리</div><div class="step-s">진행 중엔 빠른 응대가 전환을 만듭니다</div></div></div>
+      <ul class="chk">
+        <li><b>실시간 주문 확인</b> — 주문·입금 현황을 주기적으로 체크</li>
+        <li><b>문의 응대</b> — DM·댓글 질문에 빠르게 답변</li>
+        <li><b>옵션·품절 관리</b> — 인기 옵션 조기 소진 시 즉시 공지</li>
+        <li><b>목표 대비 진행률</b> — 수량 진행 상황 모니터링</li>
+      </ul>
+      <div class="tip"><b>TIP</b> 자주 나오는 질문은 미리 캡션·고정 댓글·스토리 하이라이트로 정리해두면 응대 시간이 크게 줄어요.</div>
+    </div>
+
+    <div class="card" id="s5">
+      <div class="step-h"><span class="step-n">5</span><div><div class="step-t">마감 · 발주</div><div class="step-s">숫자를 확정하고 공급사에 넘깁니다</div></div></div>
+      <ul class="chk">
+        <li><b>주문 마감</b> — 마감 시각에 주문 접수 종료</li>
+        <li><b>수량 취합</b> — 옵션별 최종 수량·미입금 정리</li>
+        <li><b>공급사 발주</b> — 확정 수량으로 발주, 출고일 확인</li>
+        <li><b>변경분 안내</b> — 품절·지연 발생 시 해당 고객에게 개별 안내</li>
+      </ul>
+      <div class="warn"><b>주의</b> 미입금·취소 건을 빼고 발주하세요. 확정 수량과 실제 발주 수량이 어긋나면 손실이 납니다.</div>
+    </div>
+
+    <div class="card" id="s6">
+      <div class="step-h"><span class="step-n">6</span><div><div class="step-t">배송 · CS</div><div class="step-s">받는 순간까지가 공구입니다</div></div></div>
+      <ul class="chk">
+        <li><b>송장 등록</b> — 출고 후 운송장 번호 입력·전달</li>
+        <li><b>배송 안내</b> — 출고 시작·예상 도착일 공지</li>
+        <li><b>교환·환불</b> — 파손·오배송 접수 및 처리 기준 안내</li>
+        <li><b>수령 확인</b> — 배송 완료 후 문제 여부 팔로업</li>
+      </ul>
+      <div class="tip"><b>TIP</b> 출고 지연이 예상되면 늦기 전에 먼저 알리는 게 클레임을 가장 크게 줄입니다.</div>
+    </div>
+
+    <div class="card" id="s7">
+      <div class="step-h"><span class="step-n">7</span><div><div class="step-t">정산 · 마무리</div><div class="step-s">수익을 확정하고 다음 공구로 연결합니다</div></div></div>
+      <ul class="chk">
+        <li><b>판매 정산</b> — 매출·공급가·수수료 정산 확인</li>
+        <li><b>리뷰 독려</b> — 수령 고객에게 후기·재구매 유도</li>
+        <li><b>결과 회고</b> — 전환율·문의 유형·재고 오차 기록</li>
+        <li><b>다음 공구 준비</b> — 반응 좋은 상품·포맷을 다음 회차로</li>
+      </ul>
+      <div class="tip"><b>TIP</b> 이번 공구의 후기·판매 데이터는 다음 공구의 릴스·상세페이지에 그대로 근거로 쓸 수 있어요.</div>
+    </div>
+
+    <div class="trust">과장 없이, 솔직하게. 모여라딜이 함께 만듭니다.<br>문의는 담당 매니저에게 연락해주세요.</div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
릴스 촬영 가이드(`supplier/guide/index.html`)의 디자인을 재사용해 **공구 진행 가이드**를 새로 추가합니다.

- 경로: `supplier/guide/gonggu.html`
- 셀러가 공구를 준비 → 정산까지 진행하는 7단계 안내 (준비 / 콘텐츠 / 오픈·홍보 / 주문관리 / 마감·발주 / 배송·CS / 정산)
- 단계별 체크리스트·TIP·주의(협찬 #광고 표기 등) 포함
- 상단에 릴스 촬영 가이드로 이동하는 링크 카드

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNXzvmSQQYndmGa7Sm1d5N)_